### PR TITLE
Ensure pluralisations are loaded from rails-i18n

### DIFF
--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -1,5 +1,6 @@
 require "rails_translation_manager/version"
 require "rails_translation_manager/railtie" if defined?(Rails)
+require "rails-i18n"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager/exporter.rb
+++ b/lib/rails_translation_manager/exporter.rb
@@ -75,8 +75,15 @@ class RailsTranslationManager::Exporter
   # (see https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/pluralization.rb#L34)
   def hash_is_for_pluralization?(hash, locale)
     plural_keys = I18n.t('i18n.plural.keys', locale: locale)
-    raise "No pluralization forms defined for #{locale}" unless plural_keys.is_a?(Array)
+    raise missing_pluralisations_message(locale) unless plural_keys.is_a?(Array)
     ((hash.keys.map(&:to_s) - plural_keys.map(&:to_s)) - ['zero']).empty?
+  end
+
+  def missing_pluralisations_message(locale)
+    "No pluralization forms defined for locale '#{locale}'. " +
+    "This probably means that the rails-18n gem does not provide a " +
+    "definition of the plural forms for this locale, you may need to " +
+    "define them yourself."
   end
 
   def key_for(prefix, key)


### PR DESCRIPTION
The `rails-i18n` gem provides standard pluralisations of various
locales. It activates these using a railtie, according to the
rails `available_locales` configuration setting.

If an app explicitly requires or loads `rails-i18n`, for example by
mentioning it in its gemfile, then all is well and the railtie will fire
properly.

However if an app uses this gem, which has a dependency on `rails-i18n`
and therefore does not explicitly require it, then the railtie will not
fire because the railtie definition will not have been required when
rails is running its initialization process.

By requiring rails-i18n in our main library file, we ensure that it the
railtie has been defined early on and that the railtie hooks will be in
place when rails initialization runs.

Prior to this I was seeing the following error when trying to run the
translation export rake task:

```
$ bundle exec rake translation:export:all[tmp/locales]
rake aborted!
No pluralization forms defined for locale 'ar'
```