### PR TITLE
Add jenkins script for publishing gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,10 @@ Rake::TestTask.new("test") do |t|
   t.verbose = true
 end
 
+require "gem_publisher"
+task :publish_gem do |t|
+  gem = GemPublisher.publish_if_updated("rails_translation_manager.gemspec", :rubygems)
+  puts "Published #{gem}" if gem
+end
+
 task :default => :test

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+set -e
+rm -f Gemfile.lock
+bundle install --path "${HOME}/bundles/${JOB_NAME}"
+export GOVUK_APP_DOMAIN=dev.gov.uk
+bundle exec rake test
+if [[ -n "$PUBLISH_GEM" ]]; then
+  bundle exec rake publish_gem --trace
+fi

--- a/rails_translation_manager.gemspec
+++ b/rails_translation_manager.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency 'gem_publisher', '~> 1.1.1'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
This automates publishing of new versions of the gem.

The `jenkins.sh` script provides a way to run this on jenkins.