### PR TITLE
Steal translations from other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,48 @@ $ rake translation:validate
 Success! No unexpected interpolation keys found.
 ```
 
+### Stealing translations from another app
+
+A third feature is the ability to "steal" one or more locales from an existing
+application. This functionality works by providing a mapping file, which defines
+how the translation keys in the the source app's files map to those in the app
+the gem is installed in.
+
+For example, given a locale file like this in the app to "steal" from:
+
+```yaml
+es:
+  document:
+    type:
+      case_study: Caso de estudio
+      consultation: Consulta
+```
+
+and a mapping file like this:
+
+```yaml
+document.type: content_item.format
+```
+
+running `rake translation:steal[es,../other_app,mapping_file_path.yml]` will
+result in the following locale file being created:
+
+```yaml
+es:
+  content_item:
+    format:
+      case_study: Caso de estudio
+      consultation: Consulta
+```
+
+The mapping file can live anywhere, as long as the full path (including filename)
+is given in the rake task invocation.
+
+The process will preserve data already in the output file if it is not
+referenced in the mapping, but will always override data belonging to keys
+that are in the mapping.
+
+
 ### Rake command reference
 
 #### Export a specific locale to CSV
@@ -150,6 +192,8 @@ rake translation:import[locale,path]
 rake translation:import:all[directory]
 ```
 
+#### 
+
 #### Regenerate all locales from the EN locale - run this after adding keys
 
 ```
@@ -160,6 +204,18 @@ rake translation:regenerate[directory]
 
 ```
 rake translation:validate
+```
+
+#### Steal a specific locale file from another app
+
+```
+rake translation:steal[locale,source_app_path,mapping_file_path]
+```
+
+#### Steal all locale files from another app
+
+```
+rake translation:steal:all[source_app_path,mapping_file_path]
 ```
 
 ### Running the test suite

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -5,4 +5,5 @@ require "rails-i18n"
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"
   autoload :Importer, "rails_translation_manager/importer"
+  autoload :Stealer, "rails_translation_manager/stealer"
 end

--- a/lib/rails_translation_manager/importer.rb
+++ b/lib/rails_translation_manager/importer.rb
@@ -1,7 +1,10 @@
 require "yaml"
 require "csv"
+require_relative "yaml_writer"
 
 class RailsTranslationManager::Importer
+  include YAMLWriter
+
   def initialize(locale, csv_path, import_directory)
     @csv_path = csv_path
     @locale = locale
@@ -25,12 +28,7 @@ class RailsTranslationManager::Importer
       end
     end
 
-    File.open(import_yml_path, "w") do |f|
-      yaml = {@locale.to_s => data}.to_yaml(separator: "")
-      yaml_without_header = yaml.split("\n").map { |l| l.gsub(/\s+$/, '') }[1..-1].join("\n")
-      f.write(yaml_without_header)
-      f.puts
-    end
+    write_yaml(import_yml_path, {@locale.to_s => data})
   end
 
   private

--- a/lib/rails_translation_manager/stealer.rb
+++ b/lib/rails_translation_manager/stealer.rb
@@ -1,0 +1,85 @@
+require "yaml"
+require "i18n"
+require_relative "yaml_writer"
+
+class RailsTranslationManager::Stealer
+  include YAMLWriter
+
+  # locale is the locale name as a string.
+  # source_app_path is the path to the root of the app to steal from.
+  # mapping_file_path is the path to a YAML file mapping translation keys in
+  # the source app to those in the target app. For example:
+  #     document.type: content_item.format
+  #     document.published: content_item.metadata.published
+  # which will import everything under "document.type" and "document.published" 
+  # in the source app, and write it to "content_item.format" and 
+  # "content_item.metadata.published" in the target app.
+  # locales_path is the path to the locale files to output, which is usually
+  # Rails.root.join('config/locales').
+  # The process will preserve data already in the output file if it is not
+  # referenced in the mapping, but will always override data belonging to keys
+  # that are in the mapping.
+  def initialize(locale, source_app_path, mapping_file_path, locales_path)
+    @locale = locale
+    @source_app_path = source_app_path
+    @mapping_file_path = mapping_file_path
+    @locales_path = locales_path
+  end
+
+  def steal_locale
+    target_data = convert_locale(get_target_data)
+    write_yaml(target_locale_path, target_data)
+  end
+
+  def convert_locale(target_data)
+    mapping_data.each do |source, target|
+      data = source_data[@locale]
+      source.split('.').each { |key| data = data.fetch(key, {}) }
+      set_recursive(target_data[@locale], target.split("."), data)
+    end
+    target_data
+  end
+
+  private
+
+  def set_recursive(hash, keys, data)
+    if keys.empty?
+      data
+    else
+      key = keys.shift
+      hash.tap do |h|
+        h.merge!({ key => set_recursive(hash.fetch(key, {}), keys, data)})
+      end
+    end
+  end
+
+  def source_locale_path
+    File.join(@source_app_path, 'config', 'locales', "#{@locale}.yml")
+  end
+
+  def source_data
+    @source_data ||= YAML.load_file(source_locale_path)
+  end
+
+  def target_locale_path
+    File.join(@locales_path, "#{@locale}.yml")
+  end
+
+  def default_target_data
+    { @locale => {} }
+  end
+
+  def get_target_data
+    if File.exist?(target_locale_path)
+      YAML.load_file(target_locale_path) || default_target_data
+    else
+      default_target_data
+    end
+  end
+
+  def mapping_data
+    @mapping_data ||= YAML.load_file(@mapping_file_path)
+  end
+
+end
+

--- a/lib/rails_translation_manager/yaml_writer.rb
+++ b/lib/rails_translation_manager/yaml_writer.rb
@@ -1,0 +1,17 @@
+require 'yaml'
+
+module YAMLWriter
+
+  # `to_yaml` outputs an initial '---\n', which is supposed to be a document
+  # separator. We don't want this in the written locale files, so we serialize
+  # to a string, remove the header and any trailing whitehspace, and write to
+  # the file.
+  def write_yaml(filepath, data)
+    File.open(filepath, "w") do |f|
+      yaml = data.to_yaml(separator: "")
+      yaml_without_header = yaml.split("\n").map { |l| l.gsub(/\s+$/, '') }[1..-1].join("\n")
+      f.write(yaml_without_header)
+      f.puts
+    end
+  end
+end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -67,4 +67,21 @@ namespace :translation do
       puts "Success! No unexpected interpolation keys found."
     end
   end
+
+  desc "Import and convert a locale file from another app."
+  task :steal, [:locale, :source_app_path, :mapping_file_path] do |t, args|
+    stealer = RailsTranslationManager::Stealer.new(args[:locale], args[:source_app_path], args[:mapping_file_path], Rails.root.join('config', 'locales'))
+    stealer.steal_locale
+  end
+
+  namespace :steal do
+    desc "Import and convert all locale files from another app."
+    task :all, [:source_app_path, :mapping_file_path] => [:environment] do |t, args|
+      I18n.available_locales.reject { |l| l == :en }.each do |locale|
+        stealer = RailsTranslationManager::Stealer.new(locale.to_s, args[:source_app_path], args[:mapping_file_path], Rails.root.join('config', 'locales'))
+        stealer.steal_locale
+      end
+    end
+  end
+
 end

--- a/test/rails_translation_manager/importer_test.rb
+++ b/test/rails_translation_manager/importer_test.rb
@@ -32,40 +32,6 @@ module RailsTranslationManager
       assert_equal expected, yaml_translation_data
     end
 
-    test 'outputs YAML without the header --- line for consistency with convention' do
-      given_csv(:fr,
-        [:key, :source, :translation],
-        ["key", "value", "le value"],
-      )
-
-      Importer.new(:fr, csv_path(:fr), import_directory).import
-
-      assert_equal "fr:", File.readlines(File.join(import_directory, "fr.yml")).first.strip
-    end
-
-    test 'outputs a newline at the end of the YAML for consistency with code editors' do
-      given_csv(:fr,
-        [:key, :source, :translation],
-        ["key", "value", "le value"],
-      )
-
-      Importer.new(:fr, csv_path(:fr), import_directory).import
-
-      assert_match /\n$/, File.readlines(File.join(import_directory, "fr.yml")).last
-    end
-
-    test 'strips whitespace from the end of lines for consistency with code editors' do
-      given_csv(:fr,
-        [:key, :source, :translation],
-        ["key", "value", nil],
-      )
-
-      Importer.new(:fr, csv_path(:fr), import_directory).import
-
-      lines = File.readlines(File.join(import_directory, "fr.yml"))
-      refute lines.any? { |line| line =~ /\s\n$/ }
-    end
-
     test 'imports arrays from CSV as arrays' do
       given_csv(:fr,
         [:key, :source, :translation],

--- a/test/rails_translation_manager/stealer_test.rb
+++ b/test/rails_translation_manager/stealer_test.rb
@@ -1,0 +1,251 @@
+require "test_helper"
+
+require "rails_translation_manager/stealer"
+require "fileutils"
+require "tmpdir"
+require "csv"
+require "i18n"
+
+module RailsTranslationManager
+  class StealerTest < Minitest::Test
+
+    test "converts subtree of items to the same depth" do
+
+      original = {
+        "fr" => {
+          "document" => {
+            "type" => {
+              "type1" => 'premier genre',
+              "type2" => 'deuxième genre',
+              "type3" => 'troisième genre'
+            }
+          }
+        }
+      }
+
+      conversion_mapping = {
+        "document.type" => "content_item.format",
+      }
+
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "format" => {
+              "type1" => 'premier genre',
+              "type2" => 'deuxième genre',
+              "type3" => 'troisième genre'
+            }
+          }
+        }
+      }
+      stealer_test(original, conversion_mapping, expected)
+    end
+
+    test "converts a subtree of items to a different depth" do
+      original = {
+        "fr" => {
+          "document" => {
+            "published" => 'publiée',
+          }
+        }
+      }
+      conversion_mapping = {
+         "document.published" => "content_item.metadata.published"
+      }
+
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "published" => 'publiée'
+            }
+          }
+        }
+      }
+
+      stealer_test(original, conversion_mapping, expected)
+    end
+
+    test "combines multiple mappings" do
+      original = {
+        "fr" => {
+          "document" => {
+            "type" => {
+              "type1" => 'premier genre',
+            },
+            "published" => 'publiée',
+          }
+        }
+      }
+
+      conversion_mapping = {
+        "document.type" => "content_item.format",
+        "document.published" => "content_item.metadata.published"
+      }
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "format" => {
+              "type1" => 'premier genre',
+            },
+            "metadata" => {
+              "published" => 'publiée',
+            }
+          }
+        }
+      }
+      stealer_test(original, conversion_mapping, expected)
+    end
+
+    test "does not copy over keys with no mapping" do
+      original = {
+        "fr" => {
+          "document" => {
+            "published" => 'publiée',
+            "do_not_want" => 'non voulu'
+          }
+        }
+      }
+      conversion_mapping = {
+         "document.published" => "content_item.metadata.published"
+      }
+
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "published" => 'publiée'
+            }
+          }
+        }
+      }
+
+      stealer_test(original, conversion_mapping, expected)
+    end
+
+    test "overrides existing translations present in mapping" do
+      original = {
+        "fr" => {
+          "document" => {
+            "published" => 'publiée',
+            "updated" => 'mise au jour',
+          }
+        }
+      }
+
+      conversion_mapping = {
+        "document.published" => "content_item.metadata.published",
+        "document.updated" => "content_item.metadata.updated"
+      }
+
+      existing = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "updated" => 'mauvaise traduction'
+            }
+          }
+        }
+      }
+
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "published" => 'publiée',
+              "updated" => 'mise au jour',
+            }
+          }
+        }
+      }
+      stealer_test(original, conversion_mapping, expected, existing)
+    end
+
+    test "does not override existing translations not in mapping" do
+      original = {
+        "fr" => {
+          "document" => {
+            "published" => 'publiée',
+          }
+        }
+      }
+
+      conversion_mapping = {
+        "document.published" => "content_item.metadata.published"
+      }
+
+      existing = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "updated" => 'mise au jour',
+            }
+          }
+        }
+      }
+
+      expected = {
+        "fr" => {
+          "content_item" => {
+            "metadata" => {
+              "published" => 'publiée',
+              "updated" => 'mise au jour',
+            }
+          }
+        }
+      }
+      stealer_test(original, conversion_mapping, expected, existing)
+    end
+
+  private
+
+    def stealer_test(original, mapping, expected, existing=nil)
+      write_source_data(original)
+      write_converter_data(mapping)
+
+      if existing.present?
+        File.open(locale_file, 'w') do |f|
+          f.puts(existing.to_yaml)
+        end
+      end
+
+      stealer = RailsTranslationManager::Stealer.new("fr", source_dir, converter_path, locales_dir)
+      stealer.steal_locale
+
+      assert_equal expected, YAML.load_file(locale_file)
+    end
+
+    def source_dir
+      @source_dir ||= Dir.mktmpdir
+    end
+
+    def source_locale_path
+      File.join(source_dir, 'config/locales')
+    end
+
+    def write_source_data(data)
+      FileUtils.mkdir_p(source_locale_path)
+      File.open(File.join(source_locale_path, 'fr.yml'), 'w') do |f|
+        f.puts(data.to_yaml)
+      end
+    end
+
+    def write_converter_data(data)
+      File.open(converter_path, 'w') do |f|
+        f.puts(data.to_yaml)
+      end
+    end
+
+    def converter_path
+      @converter_path ||= Tempfile.new('fr').path
+    end
+
+    def locales_dir
+      @locales_dir ||= Dir.mktmpdir
+    end
+
+    def locale_file
+      File.join(locales_dir, 'fr.yml')
+    end
+  end
+end

--- a/test/rails_translation_manager/yaml_writer_test.rb
+++ b/test/rails_translation_manager/yaml_writer_test.rb
@@ -1,0 +1,58 @@
+module RailsTranslationManager
+  class DummyWriter
+    include YAMLWriter
+  end
+
+  class WriterTest < Minitest::Test
+
+    def setup
+      @output_file = Tempfile.new('fr')
+    end
+
+    def teardown
+      @output_file.close
+      @output_file.unlink
+    end
+
+    test 'outputs YAML without the header --- line for consistency with convention' do
+      data = {"fr" => {
+        key1: [:source, :translation],
+        "key2" => ["value", "le value"],
+      }}
+
+      DummyWriter.new.write_yaml(output_file, data)
+
+      assert_equal "fr:", File.readlines(output_file).first.strip
+    end
+
+    test 'outputs a newline at the end of the YAML for consistency with code editors' do
+      data = {"fr" => {
+        key1: [:source, :translation],
+        "key2" => ["value", "le value"],
+      }}
+
+      DummyWriter.new.write_yaml(output_file, data)
+
+      assert_match /\n$/, File.readlines(output_file).last
+    end
+
+    test 'strips whitespace from the end of lines for consistency with code editors' do
+      data = {fr: {
+        key1: [:source, :translation],
+        "key2" => ["value", nil],
+      }}
+
+      DummyWriter.new.write_yaml(output_file, data)
+
+      lines = File.readlines(output_file)
+      refute lines.any? { |line| line =~ /\s\n$/ }
+    end
+
+  private
+
+    def output_file
+      @output_file.path
+    end
+  end
+end
+


### PR DESCRIPTION
Rake tasks to import translation files from another app, converting the keys according to a provided mapping.

The aim is to easily import all relevant translations from an app such as Whitehall. However since the original translation keys are not necessarily the same in the target app, we use a conversion file - also YAML - to map from the source keys to the destination keys. Only keys explicitly listed in that file will be imported.