### PR TITLE
Don't change the $LOAD_PATH in translation.rake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+Don't change the $LOAD_PATH in translation.rake.
+
 ## 0.0.2
 
 Added `steal` rake tasks to copy translations from another app.

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -1,4 +1,3 @@
-$LOAD_PATH.unshift(File.expand_path("../.."), __FILE__)
 require "rails_translation_manager"
 
 namespace :translation do


### PR DESCRIPTION
This should be unnecessary, as Bundler/Rubygems usually handles the
$LOAD_PATH.

I noticed this when looking at Bootsnap, as "../.." is added to the
$LOAD_PATH, this results in Bootsnap searching whatever directory is
two levels up, which can take a while if you have lots of files around
where you're using this gem....