### PR TITLE
Add ability to validate an apps locale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+Adds logic to verify locale files are in sync with each other and have the
+correct plural forms. Also introduces RSpec into the Gem which will replace
+Minitest in the coming iterations.
+
 ## 0.1.0
 
 Don't change the $LOAD_PATH in translation.rake.

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,17 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+# frozen_string_literal: true
 
-Rake::TestTask.new("test") do |t|
-  t.description = "Run tests"
-  t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
+require 'rspec/core/rake_task'
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'rails_i18n'
+
+Rake::TestTask.new('test') do |t|
+  t.description = 'Run tests'
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
 
-task :default => :test
+RSpec::Core::RakeTask.new(:spec)
+
+task default: %i[spec test]

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,0 +1,34 @@
+{
+  # Dari - this isn't an iso code. Probably should be 'prs' as per ISO 639-3.
+  dr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Latin America and Caribbean Spanish
+  "es-419": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Scottish Gaelic
+  gd: { i18n: { plural: { keys: %i[one two few other],
+                          rule:
+                            lambda do |n|
+                              if [1, 11].include?(n)
+                                :one
+                              elsif [2, 12].include?(n)
+                                :two
+                              elsif [3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19].include?(n)
+                                :few
+                              else
+                                :other
+                              end
+                            end } } },
+  # Armenian
+  hy: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Kazakh
+  kk: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Punjabi Shahmukhi
+  "pa-pk": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Sinhalese
+  si: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Uzbek
+  uz: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Chinese Hong Kong
+  "zh-hk" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Chinese Taiwan
+  "zh-tw" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+}

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   # Dari - this isn't an iso code. Probably should be 'prs' as per ISO 639-3.
   dr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
@@ -5,30 +7,43 @@
   "es-419": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Scottish Gaelic
   gd: { i18n: { plural: { keys: %i[one two few other],
-                          rule:
-                            lambda do |n|
-                              if [1, 11].include?(n)
-                                :one
-                              elsif [2, 12].include?(n)
-                                :two
-                              elsif [3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19].include?(n)
-                                :few
-                              else
-                                :other
-                              end
-                            end } } },
+                          rule: lambda do |n|
+                            if [1, 11].include?(n)
+                              :one
+                            elsif [2, 12].include?(n)
+                              :two
+                            elsif [3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19].include?(n)
+                              :few
+                            else
+                              :other
+                            end
+                          end } } },
+  # Gujarati
+  gu: { i18n: { plural: { keys: %i[one other], rule: ->(n) { [0, 1].include?(n) ? :one : :other } } } },
   # Armenian
-  hy: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  hy: { i18n: { plural: { keys: %i[one other], rule: ->(n) { [0, 1].include?(n) ? :one : :other } } } },
   # Kazakh
   kk: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Pashto
+  ps: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Punjabi Shahmukhi
-  "pa-pk": { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  "pa-pk": { i18n: { plural: { keys: %i[one other], rule: ->(n) { [0, 1].include?(n) ? :one : :other } } } },
   # Sinhalese
-  si: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  si: { i18n: { plural: { keys: %i[one other], rule: ->(n) { [0, 1].include?(n) ? :one : :other } } } },
+  # Somali
+  so: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Albanian
+  sq: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Norwegian
+  no: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Tamil
+  ta: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  # Turkmen
+  tk: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Uzbek
   uz: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Chinese Hong Kong
-  "zh-hk" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  'zh-hk' => { i18n: { plural: { keys: %i[other], rule: -> { :other } } } },
   # Chinese Taiwan
-  "zh-tw" => { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
+  'zh-tw' => { i18n: { plural: { keys: %i[other], rule: -> { :other } } } }
 }

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 require "rails_translation_manager/version"
 require "rails_translation_manager/railtie" if defined?(Rails)
 require "rails-i18n"
+
+require "rails_translation_manager/locale_checker/locale_checker_helper"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -13,4 +13,12 @@ module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"
   autoload :Importer, "rails_translation_manager/importer"
   autoload :Stealer, "rails_translation_manager/stealer"
+
+  rails_i18n_path = Gem::Specification.find_by_name("rails-i18n").gem_dir
+  rails_translation_manager = Gem::Specification.find_by_name("rails_translation_manager").gem_dir
+
+  I18n.load_path.concat(
+    Dir["#{rails_i18n_path}/rails/pluralization/*.rb"],
+    ["#{rails_translation_manager}/config/locales/plurals.rb"]
+  )
 end

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -10,6 +10,7 @@ require "rails_translation_manager/locale_checker/missing_foreign_locales"
 require "rails_translation_manager/locale_checker/missing_english_locales"
 require "rails_translation_manager/locale_checker/plural_forms"
 require "rails_translation_manager/locale_checker/incompatible_plurals"
+require "rails_translation_manager/locale_checker/all_locales"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -11,6 +11,7 @@ require "rails_translation_manager/locale_checker/missing_english_locales"
 require "rails_translation_manager/locale_checker/plural_forms"
 require "rails_translation_manager/locale_checker/incompatible_plurals"
 require "rails_translation_manager/locale_checker/all_locales"
+require "rails_translation_manager/locale_checker"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -8,6 +8,7 @@ require "rails_translation_manager/locale_checker/base_checker"
 require "rails_translation_manager/locale_checker/locale_checker_helper"
 require "rails_translation_manager/locale_checker/missing_foreign_locales"
 require "rails_translation_manager/locale_checker/missing_english_locales"
+require "rails_translation_manager/locale_checker/plural_forms"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -9,6 +9,7 @@ require "rails_translation_manager/locale_checker/locale_checker_helper"
 require "rails_translation_manager/locale_checker/missing_foreign_locales"
 require "rails_translation_manager/locale_checker/missing_english_locales"
 require "rails_translation_manager/locale_checker/plural_forms"
+require "rails_translation_manager/locale_checker/incompatible_plurals"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -6,6 +6,8 @@ require "rails-i18n"
 
 require "rails_translation_manager/locale_checker/base_checker"
 require "rails_translation_manager/locale_checker/locale_checker_helper"
+require "rails_translation_manager/locale_checker/missing_foreign_locales"
+require "rails_translation_manager/locale_checker/missing_english_locales"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -4,6 +4,7 @@ require "rails_translation_manager/version"
 require "rails_translation_manager/railtie" if defined?(Rails)
 require "rails-i18n"
 
+require "rails_translation_manager/locale_checker/base_checker"
 require "rails_translation_manager/locale_checker/locale_checker_helper"
 
 module RailsTranslationManager

--- a/lib/rails_translation_manager/locale_checker.rb
+++ b/lib/rails_translation_manager/locale_checker.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RailsTranslationManager
+  class LocaleChecker
+    attr_reader :locale_path
+
+    CHECKER_CLASSES = [MissingEnglishLocales,
+                       MissingForeignLocales,
+                       IncompatiblePlurals].freeze
+
+    def initialize(locale_path)
+      @locale_path = locale_path
+    end
+
+    def validate_locales
+      output_result
+    rescue AllLocales::NoLocaleFilesFound => e
+      puts e
+      false
+    end
+
+    private
+
+    def output_result
+      errors = checker_errors.compact
+
+      if errors.blank?
+        puts "Locale files are in sync, nice job!"
+        true
+      else
+        errors.each do |error_message|
+          puts "\n"
+          puts error_message
+          puts "\n"
+        end
+        false
+      end
+    end
+
+    def checker_errors
+      CHECKER_CLASSES.flat_map do |checker|
+        checker.new(all_locales).report
+      end
+    end
+
+    def all_locales
+      @all_locales ||= AllLocales.new(locale_path).generate
+    end
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/all_locales.rb
+++ b/lib/rails_translation_manager/locale_checker/all_locales.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class AllLocales
+  attr_reader :locale_path
+
+  def initialize(locale_path)
+    @locale_path = locale_path
+  end
+
+  def generate
+    paths = locale_file_paths.compact
+
+    raise NoLocaleFilesFound, "No locale files found for the supplied path" if paths.blank?
+
+    paths.flat_map do |locale_group|
+      {
+        locale: locale_group[:locale],
+        keys: all_keys_for_locale(locale_group)
+      }
+    end
+  end
+
+  private
+
+  def locale_file_paths
+    I18n.available_locales.map do |locale|
+      grouped_paths = Dir[locale_path].select do |path|
+        locale = locale.downcase
+
+        path =~ %r{/#{locale}/} || path =~ %r{/#{locale}\.yml$}
+      end
+
+      { locale: locale.downcase, paths: grouped_paths } if grouped_paths.present?
+    end
+  end
+
+  def all_keys_for_locale(locale_group)
+    locale_group[:paths].flat_map do |path|
+      keys_from_file(file_path: path)
+    end
+  end
+
+  def keys_from_file(locale_hash: nil, key_chain: nil, locale_keys: [], file_path: nil)
+    locale_hash ||= YAML.load_file(file_path)
+    keys = locale_hash.keys
+    keys.each do |key|
+      if locale_hash.fetch(key).is_a?(Hash)
+        keys_from_file(locale_hash: locale_hash.fetch(key), key_chain: "#{key_chain}.#{key}", locale_keys: locale_keys)
+      else
+        keys.each do |final_key|
+          locale_keys << "#{key_chain}.#{final_key}"
+        end
+      end
+    end
+
+    # remove locale prefix from keys, e.g: ".en.browse.page" -> "browse.page"
+    locale_keys.uniq.map { |key| key.split(".")[2..].join(".") }
+  end
+
+  class NoLocaleFilesFound < StandardError; end
+end

--- a/lib/rails_translation_manager/locale_checker/base_checker.rb
+++ b/lib/rails_translation_manager/locale_checker/base_checker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BaseChecker
+  attr_reader :all_locales
+
+  def initialize(all_locales)
+    @all_locales = all_locales
+  end
+
+  def report
+    raise "You must define a `report` method in the child class!"
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/incompatible_plurals.rb
+++ b/lib/rails_translation_manager/locale_checker/incompatible_plurals.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class IncompatiblePlurals < BaseChecker
+  include LocaleCheckerHelper
+
+  def report
+    format_plural_errors if plural_errors.present?
+  end
+
+  private
+
+  def format_plural_errors
+    <<~OUTPUT.chomp
+      \e[31m[ERROR]\e[0m Incompatible plural forms, for:
+
+      #{plural_errors.join("\n\n")}
+
+      \e[1mIf the keys reported above are not plurals, rename them avoiding plural keywords: #{PLURAL_KEYS}\e[22m
+    OUTPUT
+  end
+
+  def plural_errors
+    @plural_errors ||= grouped_plural_keys_for_locale.flat_map do |plurals|
+      plural_form = all_plural_forms[plurals[:locale]]
+
+      if plural_form.blank?
+        "- \e[31m[ERROR]\e[0m Please add plural form for '#{plurals[:locale]}' <link to future documentation>"
+      else
+        incompatible_plurals(plurals, plural_form)
+      end
+    end
+  end
+
+  def incompatible_plurals(plurals, plural_form)
+    error_messages = plurals[:groups].map do |plural_group|
+      actual_plural_form = plural_group[:keys].sort
+
+      next if actual_plural_form == plural_form.sort
+
+      "- '#{plurals[:locale]}', with parent '#{plural_group[:parent]}'. Expected: #{plural_form}, actual: #{actual_plural_form}"
+    end
+
+    error_messages.compact
+  end
+
+  def grouped_plural_keys_for_locale
+    all_locales.map do |locale|
+      {
+        locale: locale[:locale],
+        groups: grouped_plural_keys(only_plurals(locale[:keys]))
+      }
+    end
+  end
+
+  def grouped_plural_keys(keys)
+    # %w[parent.key parent.other_key] -> [{ parent: "parent", keys: %w[key other_key] }]
+    group_by_parent_keys(keys).map do |plural_key_group|
+      {
+        parent: plural_key_group.first,
+        keys: plural_key_group.last.map { |key_chain| key_chain.split(".").last.to_sym }
+      }
+    end
+  end
+
+  def group_by_parent_keys(keys)
+    # %w[parent.key parent.other_key] -> { "parent" => %w[parent.key parent.other_key] }
+    keys.group_by do |key|
+      key.split('.')[0..-2].join('.')
+    end
+  end
+
+  def only_plurals(keys)
+    keys.select { |key| key_is_plural?(key) }
+  end
+
+  def all_plural_forms
+    @all_plural_forms ||= PluralForms.all
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/locale_checker_helper.rb
+++ b/lib/rails_translation_manager/locale_checker/locale_checker_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LocaleCheckerHelper
+  PLURAL_KEYS = %w[zero one two few many other].freeze
+
+  def exclude_plurals(keys)
+    keys.reject { |key| key_is_plural?(key) }
+  end
+
+  def group_keys(locales)
+    locales.keys.group_by do |key|
+      locales[key]
+    end
+  end
+
+  def english_keys_excluding_plurals(all_locales)
+    exclude_plurals(all_locales.find { |locale| locale[:locale] == :en }[:keys])
+  end
+
+  def key_is_plural?(key)
+    PLURAL_KEYS.include?(key.split(".").last)
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
+++ b/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MissingEnglishLocales < BaseChecker
+  include LocaleCheckerHelper
+
+  def report
+    grouped_missing_keys = group_keys(missing_english_locales)
+
+    format_missing_english_locales(grouped_missing_keys) if grouped_missing_keys.present?
+  end
+
+  private
+
+  def format_missing_english_locales(keys)
+    formatted_keys = keys.to_a.map do |group|
+      "\e[1mMissing English keys:\e[22m #{group[0]}\n\e[1mFound in:\e[22m #{group[1]}"
+    end
+
+    "\e[31m[ERROR]\e[0m Missing English locales, either remove these keys from the foreign locales or add them to the English locales\n\n#{formatted_keys.join("\n\n")}"
+  end
+
+  def missing_english_locales
+    all_locales.each_with_object({}) do |locale, hsh|
+      missing_keys = exclude_plurals(locale[:keys]) - english_keys_excluding_plurals(all_locales)
+
+      next if missing_keys.blank?
+
+      hsh[locale[:locale]] = missing_keys
+    end
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/missing_foreign_locales.rb
+++ b/lib/rails_translation_manager/locale_checker/missing_foreign_locales.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MissingForeignLocales < BaseChecker
+  include LocaleCheckerHelper
+
+  def report
+    grouped_missing_keys = group_keys(missing_foreign_locales)
+
+    format_missing_foreign_locales(grouped_missing_keys) if grouped_missing_keys.present?
+  end
+
+  private
+
+  def format_missing_foreign_locales(keys)
+    formatted_keys = keys.to_a.map do |group|
+      "\e[1mMissing foreign keys:\e[22m #{group[0]}\n\e[1mAbsent from:\e[22m #{group[1]}"
+    end
+
+    "\e[31m[ERROR]\e[0m Missing foreign locales, either add these keys to the foreign locales or remove them from the English locales\e[0m\n\n#{formatted_keys.join("\n\n")}"
+  end
+
+  def missing_foreign_locales
+    all_locales.each_with_object({}) do |locale, hsh|
+      missing_keys = english_keys_excluding_plurals(all_locales) - exclude_plurals(locale[:keys])
+
+      next if missing_keys.blank?
+
+      hsh[locale[:locale]] = missing_keys
+    end
+  end
+end

--- a/lib/rails_translation_manager/locale_checker/plural_forms.rb
+++ b/lib/rails_translation_manager/locale_checker/plural_forms.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PluralForms
+  def self.all
+    I18n.available_locales.each_with_object({}) do |locale, hsh|
+      begin
+        # fetches plural form (rule) from rails-i18n for locale
+        plural_form = I18n.with_locale(locale) { I18n.t!("i18n.plural.keys") }.sort
+      rescue I18n::MissingTranslationData
+        plural_form = nil
+      end
+
+      hsh[locale.downcase] = plural_form
+    end
+  end
+end

--- a/rails_translation_manager.gemspec
+++ b/rails_translation_manager.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rspec"
 end

--- a/spec/locales/in_sync/cy/browse.yml
+++ b/spec/locales/in_sync/cy/browse.yml
@@ -1,0 +1,12 @@
+---
+cy:
+  in_sync:
+    key: bwyd
+    second_key: cath
+  some_plurals:
+    few:
+    many:
+    one:
+    other:
+    two:
+    zero:

--- a/spec/locales/in_sync/en/browse.yml
+++ b/spec/locales/in_sync/en/browse.yml
@@ -1,0 +1,8 @@
+---
+cy:
+  in_sync:
+    key: food
+    second_key: cat
+  some_plurals:
+    one:
+    other:

--- a/spec/locales/out_of_sync/cy.yml
+++ b/spec/locales/out_of_sync/cy.yml
@@ -1,0 +1,3 @@
+---
+cy:
+  other_test: key

--- a/spec/locales/out_of_sync/en.yml
+++ b/spec/locales/out_of_sync/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  test: key
+  wrong_plural:
+    one: correct
+    zero: failure

--- a/spec/rails_translation_manager/locale_checker/all_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/all_locales_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe AllLocales do
+  context "when there are locale files" do
+    it "generates an array of hashes for all locales" do
+      expect(described_class.new("spec/locales/out_of_sync/*.yml").generate)
+        .to eq(
+          [
+            { keys: %w[test wrong_plural wrong_plural.one wrong_plural.zero], locale: :en },
+            { keys: %w[other_test], locale: :cy }
+          ]
+      )
+    end
+  end
+
+  context "when there aren't any locale files present" do
+    it "raises an error" do
+      expect { described_class.new("path/to/none/existant/locale/files").generate }
+        .to raise_error(AllLocales::NoLocaleFilesFound, 'No locale files found for the supplied path')
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker/incompatible_plurals_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/incompatible_plurals_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe IncompatiblePlurals do
+  context "when there are missing plurals" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.some_key.other browse.some_other_key.one]
+        }
+      ]
+    end
+
+    before do
+      allow(PluralForms).to receive(:all).and_return({ en: %i[one other] })
+    end
+
+    it "returns the missing plural forms" do
+      expect(described_class.new(all_locales).report)
+        .to eq(
+          <<~OUTPUT.chomp
+            \e[31m[ERROR]\e[0m Incompatible plural forms, for:
+
+            - 'en', with parent 'browse.some_key'. Expected: [:one, :other], actual: [:other]
+
+            - 'en', with parent 'browse.some_other_key'. Expected: [:one, :other], actual: [:one]
+
+            \e[1mIf the keys reported above are not plurals, rename them avoiding plural keywords: #{LocaleCheckerHelper::PLURAL_KEYS}\e[22m
+          OUTPUT
+        )
+    end
+  end
+
+  context "when there aren't any missing plurals" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.some_key.other browse.some_key.one]
+        }
+      ]
+    end
+
+    before do
+      allow(PluralForms).to receive(:all).and_return({ en: %i[one other] })
+    end
+
+    it "returns nil" do
+      expect(described_class.new(all_locales).report)
+        .to be_nil
+    end
+  end
+
+  context "when plural forms aren't available for the locales" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.some_key.one browse.some_key.other]
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.some_key.few
+                   browse.some_key.many
+                   browse.some_key.one
+                   browse.some_key.other
+                   browse.some_key.two
+                   browse.some_key.zero]
+        }
+      ]
+    end
+
+    before do
+      allow(PluralForms).to receive(:all).and_return({ cy: nil, en: nil })
+    end
+
+    it "outputs the missing plural forms" do
+      expect(described_class.new(all_locales).report)
+        .to eq(
+          <<~OUTPUT.chomp
+            \e[31m[ERROR]\e[0m Incompatible plural forms, for:
+
+            - \e[31m[ERROR]\e[0m Please add plural form for 'en' <link to future documentation>
+
+            - \e[31m[ERROR]\e[0m Please add plural form for 'cy' <link to future documentation>
+
+            \e[1mIf the keys reported above are not plurals, rename them avoiding plural keywords: #{LocaleCheckerHelper::PLURAL_KEYS}\e[22m
+          OUTPUT
+        )
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker/locale_checker_helper_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/locale_checker_helper_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe LocaleCheckerHelper do
+  include LocaleCheckerHelper
+
+  describe "#exclude_plurals" do
+    it "excludes plural groups" do
+      expect(exclude_plurals(%w[key.one key.other]))
+        .to eq([])
+    end
+
+    it "doesn't exclude non-plurals" do
+      expect(exclude_plurals(%w[thing.bing red.blue]))
+        .to eq(%w[thing.bing red.blue])
+    end
+  end
+
+  describe "#group_keys" do
+    it "groups locales by keys" do
+      keys = {
+        en: %w[key.first key.second],
+        fr: %w[key.first key.second],
+        es: %w[key.second]
+      }
+
+      expect(group_keys(keys))
+        .to eq(
+          {
+            %w[key.first key.second] => %i[en fr],
+            %w[key.second] => %i[es]
+          }
+        )
+    end
+  end
+
+  describe "#english_keys_excluding_plurals" do
+    it "returns english keys excluding plurals" do
+      keys = [
+        { locale: :en, keys: %w[key.english plural.other] },
+        { locale: :fr, keys: %w[key.french] }
+      ]
+
+      expect(english_keys_excluding_plurals(keys))
+        .to eq(%w[key.english])
+    end
+  end
+
+  describe "#key_is_plural?" do
+    it "returns true if key is a plural keyword" do
+      expect(key_is_plural?("other"))
+        .to eq(true)
+    end
+
+    it "returns false if key isn't a plural keyword" do
+      expect(key_is_plural?("random"))
+        .to eq(false)
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MissingEnglishLocales do
+  context "where there are missing English locales" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.same_key]
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.same_key browse.extra_key]
+        }
+      ]
+    end
+
+    it "outputs the missing locales" do
+      expect(described_class.new(all_locales).report)
+        .to eq(
+          <<~OUTPUT.chomp
+            \e[31m[ERROR]\e[0m Missing English locales, either remove these keys from the foreign locales or add them to the English locales
+
+            \e[1mMissing English keys:\e[22m ["browse.extra_key"]
+            \e[1mFound in:\e[22m [:cy]
+          OUTPUT
+        )
+    end
+  end
+
+  context "where there aren't missing English locales" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.same_key]
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.same_key]
+        }
+      ]
+    end
+
+    it 'outputs nil' do
+      expect(described_class.new(all_locales).report)
+        .to be_nil
+    end
+  end
+
+  context "when there are plurals" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: []
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.plurals.one browse.fake_plurals.other]
+        }
+      ]
+    end
+
+    it "doesn't include them in the report" do
+      expect(described_class.new(all_locales).report)
+        .to be_nil
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker/missing_foreign_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/missing_foreign_locales_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MissingForeignLocales do
+  context "when there are missing foreign locales" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.same_key browse.extra_nested_key.nest]
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.same_key]
+        },
+        {
+          locale: :fr,
+          keys: %w[browse.same_key]
+        }
+      ]
+    end
+
+    before do
+      I18n.available_locales << %i[fr]
+    end
+
+    it "outputs the missing locales and groups them by common keys" do
+      expect(described_class.new(all_locales).report)
+        .to eq(
+          <<~OUTPUT.chomp
+            \e[31m[ERROR]\e[0m Missing foreign locales, either add these keys to the foreign locales or remove them from the English locales\e[0m
+
+            \e[1mMissing foreign keys:\e[22m ["browse.extra_nested_key.nest"]
+            \e[1mAbsent from:\e[22m [:cy, :fr]
+          OUTPUT
+        )
+    end
+  end
+
+  context "when there aren't missing foreign locales" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.same_key]
+        },
+        {
+          locale: :cy,
+          keys: %w[browse.same_key]
+        }
+      ]
+    end
+
+    it "outputs nil" do
+      expect(described_class.new(all_locales).report)
+        .to be_nil
+    end
+  end
+
+  context "when there are plurals" do
+    let(:all_locales) do
+      [
+        {
+          locale: :en,
+          keys: %w[browse.plurals.one browse.fake_plurals.other]
+        },
+        {
+          locale: :cy,
+          keys: []
+        }
+      ]
+    end
+
+    it "doesn't include them in the report" do
+      expect(described_class.new(all_locales).report)
+        .to be_nil
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker/plural_forms_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/plural_forms_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PluralForms do
+  it "returns plural forms" do
+    expect(described_class.all).to include(
+      { cy: %i[few many one other two zero], en: %i[one other] }
+    )
+  end
+
+  context "when there are missing plural forms" do
+    around do |example|
+      load_path = I18n.load_path
+      # strips I18n of all pluralization files (rules)
+      I18n.load_path = I18n.load_path.flatten.reject { |path| path =~ /plural/ }
+
+      example.run
+
+      I18n.load_path = load_path
+    end
+
+    it "returns nil for associated locales" do
+      expect(described_class.all).to include({ cy: nil, en: nil })
+    end
+  end
+end

--- a/spec/rails_translation_manager/locale_checker_spec.rb
+++ b/spec/rails_translation_manager/locale_checker_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RailsTranslationManager::LocaleChecker do
+  context "when the locales are valid" do
+    it "calls each checker class" do
+      described_class::CHECKER_CLASSES.each do |checker|
+        expect_any_instance_of(checker).to receive(:report)
+      end
+
+      described_class.new("spec/locales/in_sync/**/*.yml").validate_locales
+    end
+
+    it "outputs a confirmation" do
+      expect { described_class.new("spec/locales/in_sync/**/*.yml").validate_locales }
+        .to output("Locale files are in sync, nice job!\n").to_stdout
+    end
+
+    it "returns true" do
+      expect(described_class.new("spec/locales/in_sync/**/*.yml").validate_locales)
+        .to eq(true)
+    end
+  end
+
+  context "when the locales are not valid" do
+    it "calls each checker class" do
+      described_class::CHECKER_CLASSES.each do |checker|
+        expect_any_instance_of(checker).to receive(:report)
+      end
+
+      described_class.new("spec/locales/out_of_sync/*.yml").validate_locales
+    end
+
+    it "outputs the report" do
+      printed = capture_stdout do
+        described_class.new("spec/locales/out_of_sync/*.yml").validate_locales
+      end
+
+      expect(printed.scan(/\[ERROR\]/).count).to eq(3)
+    end
+
+    it "returns false" do
+      expect(described_class.new("spec/locales/out_of_sync/*.yml").validate_locales)
+        .to eq(false)
+    end
+  end
+
+  context "when the locale path doesn't relate to any YAML files" do
+    it "doesn't call any checker classes" do
+      described_class::CHECKER_CLASSES.each do |checker|
+        expect_any_instance_of(checker).to_not receive(:report)
+      end
+
+      described_class.new("some/random/path").validate_locales
+    end
+
+    it "outputs an error message" do
+      expect { described_class.new("some/random/path").validate_locales }
+        .to output("No locale files found for the supplied path\n").to_stdout
+    end
+
+    it "returns false" do
+      expect(described_class.new("some/random/path").validate_locales)
+        .to eq(false)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_translation_manager"
+
+RSpec.configure do |config|
+  config.before do
+    I18n.available_locales = %i[en cy]
+    config.before { allow($stdout).to receive(:puts) }
+  end
+
+  def capture_stdout(&blk)
+    old = $stdout
+    $stdout = fake = StringIO.new
+    blk.call
+    fake.string
+  ensure
+    $stdout = old
+  end
+end


### PR DESCRIPTION
This PR is the first step to being able to validate an applications locale files. The checks revolve around making sure the locale files are in sync with each and that they are using the correct plural forms. Before these checks are implemented in the frontend applications, we should create documentation that explains what to do if one of the checks fail. I've provided a brief description but proper documentation is needed.

More info in the commits ->

### Screenshot 1

<img width="1274" alt="Screenshot 2021-09-27 at 18 11 04" src="https://user-images.githubusercontent.com/24479188/134956374-aba76191-4ab6-4bd1-ab3d-dd450561ed2a.png">


### Screenshot 2

<img width="935" alt="Screenshot 2021-09-27 at 18 10 45" src="https://user-images.githubusercontent.com/24479188/134956398-f8b4b4aa-0a36-468b-8b97-5b8533c63bb9.png">


Trello:
https://trello.com/c/Ma1ygjNc/2567-add-automated-tests-to-check-translations-5
