### PR TITLE
Integrate RTM with I18n-tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/tmp/
+/tmp/*
 *.bundle
 *.so
 *.o

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -12,6 +12,7 @@ require "rails_translation_manager/locale_checker/plural_forms"
 require "rails_translation_manager/locale_checker/incompatible_plurals"
 require "rails_translation_manager/locale_checker/all_locales"
 require "rails_translation_manager/locale_checker"
+require "rails_translation_manager/cleaner"
 
 module RailsTranslationManager
   autoload :Exporter, "rails_translation_manager/exporter"

--- a/lib/rails_translation_manager/cleaner.rb
+++ b/lib/rails_translation_manager/cleaner.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsTranslationManager
+  class Cleaner
+
+    def initialize(path)
+      @path = path
+    end
+
+    def clean
+      `find #{@path} -type f -exec perl -p -i -e \"s/[ \t]$//g\" {} \\;`
+    end
+  end
+end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -86,15 +86,17 @@ namespace :translation do
 
   desc "Add missing translations"
   task(:add_missing, [:locale] => [:environment]) do |t, args|
-    locale = args[:locale] || "en"
+    locale = args[:locale]
 
-    I18n::Tasks::CLI.start(["add-missing", "-l", locale])
+    i18n_args = ["add-missing", "--nil-value"]
+    i18n_args << ["-l", locale] if locale
+    I18n::Tasks::CLI.start(i18n_args.flatten)
   end
 
   desc "Normalize translations"
   task(:normalize, [:locale] => [:environment]) do |t, args|
-    locale = args[:locale] || "en"
+    locale = args[:locale]
 
-    I18n::Tasks::CLI.start(["normalize", "-l", locale])
+    locale ? I18n::Tasks::CLI.start(["normalize", "-l", locale]) : I18n::Tasks::CLI.start(["normalize"])
   end
 end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -90,7 +90,9 @@ namespace :translation do
 
     i18n_args = ["add-missing", "--nil-value"]
     i18n_args << ["-l", locale] if locale
+
     I18n::Tasks::CLI.start(i18n_args.flatten)
+    RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 
   desc "Normalize translations"
@@ -98,5 +100,6 @@ namespace :translation do
     locale = args[:locale]
 
     locale ? I18n::Tasks::CLI.start(["normalize", "-l", locale]) : I18n::Tasks::CLI.start(["normalize"])
+    RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -1,4 +1,5 @@
 require "rails_translation_manager"
+require "i18n/tasks/cli"
 
 namespace :translation do
 
@@ -83,4 +84,17 @@ namespace :translation do
     end
   end
 
+  desc "Add missing translations"
+  task(:add_missing, [:locale] => [:environment]) do |t, args|
+    locale = args[:locale] || "en"
+
+    I18n::Tasks::CLI.start(["add-missing", "-l", locale])
+  end
+
+  desc "Normalize translations"
+  task(:normalize, [:locale] => [:environment]) do |t, args|
+    locale = args[:locale] || "en"
+
+    I18n::Tasks::CLI.start(["normalize", "-l", locale])
+  end
 end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -1,5 +1,6 @@
 require "rails_translation_manager"
 require "i18n/tasks/cli"
+require_relative "../tasks/translation_helper"
 
 namespace :translation do
 
@@ -86,20 +87,13 @@ namespace :translation do
 
   desc "Add missing translations"
   task(:add_missing, [:locale] => [:environment]) do |t, args|
-    locale = args[:locale]
-
-    i18n_args = ["add-missing", "--nil-value"]
-    i18n_args << ["-l", locale] if locale
-
-    I18n::Tasks::CLI.start(i18n_args.flatten)
+    I18n::Tasks::CLI.start(TranslationHelper.new(["add-missing", "--nil-value"], args[:locale]).with_optional_locale)
     RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 
   desc "Normalize translations"
   task(:normalize, [:locale] => [:environment]) do |t, args|
-    locale = args[:locale]
-
-    locale ? I18n::Tasks::CLI.start(["normalize", "-l", locale]) : I18n::Tasks::CLI.start(["normalize"])
+    I18n::Tasks::CLI.start(TranslationHelper.new(["normalize"], args[:locale]).with_optional_locale)
     RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 end

--- a/lib/tasks/translation_helper.rb
+++ b/lib/tasks/translation_helper.rb
@@ -1,0 +1,11 @@
+class TranslationHelper
+
+  def initialize(task_options, locale)
+    @task_options = task_options
+    @locale = locale
+  end
+
+  def with_optional_locale
+    @locale ? @task_options << ["-l", @locale] : @task_options
+  end
+end

--- a/rails_translation_manager.gemspec
+++ b/rails_translation_manager.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "byebug"
 end

--- a/rails_translation_manager.gemspec
+++ b/rails_translation_manager.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails-i18n"
   spec.add_dependency "activesupport"
+  spec.add_dependency "i18n-tasks"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/locales/cleaner/clean.yml
+++ b/spec/locales/cleaner/clean.yml
@@ -1,0 +1,5 @@
+---
+en:
+  test: key
+    key_1: foo
+    key_2: bar

--- a/spec/locales/cleaner/with_whitespace.yml
+++ b/spec/locales/cleaner/with_whitespace.yml
@@ -1,0 +1,5 @@
+---
+en:
+  test: key 
+    key_1: foo 
+    key_2: bar 

--- a/spec/rails_translation_manager/cleaner_spec.rb
+++ b/spec/rails_translation_manager/cleaner_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe RailsTranslationManager::Cleaner do
+
+  before(:each) do
+    FileUtils.cp('spec/locales/cleaner/with_whitespace.yml', 'tmp/')
+  end
+
+  it 'removes whitespace at the end of the line' do
+    described_class.new('tmp').clean
+    expect(FileUtils.compare_file('tmp/with_whitespace.yml', 'spec/locales/cleaner/clean.yml')).to be_truthy
+  end
+end

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,0 +1,7 @@
+require 'rake'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    Dir.glob('lib/tasks/*.rake').each { |r| Rake::DefaultLoader.new.load r }
+  end
+end

--- a/spec/tasks/translation_spec.rb
+++ b/spec/tasks/translation_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require_relative '../../spec/support/tasks'  
+
+describe 'rake tasks' do
+  before do
+    fake_rails = double()
+    fake_rails.stub(:root) { Pathname.new('spec') }
+    stub_const("Rails", fake_rails)
+  end
+
+  describe 'translation:add_missing', type: :task do
+    let(:task) { Rake::Task["translation:add_missing"] }
+  
+    it 'is executed' do
+      expect { task.execute }.to output.to_stdout
+    end
+
+    it 'triggers i18n task and allows to receive the right arguments' do
+      allow(I18n::Tasks::CLI).to receive(:start)
+      task.execute
+      expect(I18n::Tasks::CLI).to have_received(:start).with(["add-missing", "--nil-value"])
+    end
+  end
+
+  describe 'translation:normalize', type: :task do
+    let(:task) { Rake::Task["translation:normalize"] }
+  
+    it 'is executed' do
+      expect { task.execute }.to_not output.to_stdout
+    end
+
+    it 'triggers i18n task and allows to receive the right arguments' do
+      allow(I18n::Tasks::CLI).to receive(:start)
+      task.execute
+      expect(I18n::Tasks::CLI).to have_received(:start).with(["normalize"])
+    end
+  end
+end


### PR DESCRIPTION
Add i18n-tasks to Rails Translation Manager 

Add wrappers around `add-missing` & `normalize` tasks to be able to use them and have a common interface for both Gems.

[Trello card](https://trello.com/c/6RSfGJJa/2685-add-i18n-tasks-to-rails-translation-manager-5)