### PR TITLE
Update application root for app

### DIFF
--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -26,4 +26,10 @@ module RailsTranslationManager
     Dir["#{rails_i18n_path}/rails/pluralization/*.rb"],
     ["#{rails_translation_manager}/config/locales/plurals.rb"]
   )
+
+  root = Rails.root.to_s
+  if root =~ /govuk_publishing_components/
+    real_components_root = root.split("govuk_publishing_components").first + "govuk_publishing_components"
+    Rails.application.config.root = real_components_root
+  end
 end


### PR DESCRIPTION
We use `Rails.root` quite a lot in this Gem to figure out the calling
applications root directory. This is a nice means of working this out,
however for govuk_publishing_components this was being reported as
`govuk_publishing_component/spec/dummy` due to the Gem not being a true
Rails app and implementing it's own 'dummy' Rails app which was
overwriting the root dir.

This hack sets the true root directory for govuk_publishing_components
and is written so it should be future proof if it changes to something
other than `spec/dummy`.

Trello:
https://trello.com/c/k4rrt3UG/2686-update-csv-import-rails-translation-manager-3