### PR TITLE
Allow multiple files per language to be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+Allow multiple files per language to be imported. https://github.com/alphagov/rails_translation_manager/pull/20
+
 ## 1.0.0
 
 Adds logic to verify locale files are in sync with each other and have the

--- a/lib/rails_translation_manager/importer.rb
+++ b/lib/rails_translation_manager/importer.rb
@@ -5,38 +5,39 @@ require_relative "yaml_writer"
 class RailsTranslationManager::Importer
   include YAMLWriter
 
-  attr_reader :locale, :csv_path, :import_directory
+  attr_reader :locale, :csv_path, :import_directory, :multiple_files_per_language
 
-  def initialize(locale:, csv_path:, import_directory:)
+  def initialize(locale:, csv_path:, import_directory:, multiple_files_per_language:)
     @locale = locale
     @csv_path = csv_path
     @import_directory = import_directory
+    @multiple_files_per_language = multiple_files_per_language
   end
 
   def import
     csv = CSV.read(csv_path, headers: true, header_converters: :downcase)
-    data = {}
-    csv.each do |row|
+
+    multiple_files_per_language ? import_csv_into_multiple_files(csv) : import_csv(csv)
+  end
+
+  private
+
+  def import_csv(csv, import_yml_path = File.join(import_directory, "#{locale}.yml"))
+    data = csv.each_with_object({}) do |row, hash|
       key = row["key"]
       key_parts = key.split(".")
       if key_parts.length > 1
-        leaf_node = (data[key_parts.first] ||= {})
+        leaf_node = (hash[key_parts.first] ||= {})
         key_parts[1..-2].each do |part|
           leaf_node = (leaf_node[part] ||= {})
         end
         leaf_node[key_parts.last] = parse_translation(row["translation"])
       else
-        data[key_parts.first] = parse_translation(row["translation"])
+        hash[key_parts.first] = parse_translation(row["translation"])
       end
     end
 
-    write_yaml(import_yml_path, {locale.to_s => data})
-  end
-
-  private
-
-  def import_yml_path
-    File.join(import_directory, "#{locale}.yml")
+    write_yaml(import_yml_path, { locale.to_s => data })
   end
 
   def parse_translation(translation)
@@ -56,5 +57,20 @@ class RailsTranslationManager::Importer
     else
       translation
     end
+  end
+
+  def import_csv_into_multiple_files(csv)
+    group_csv_by_file(csv).each do |group|
+      language_dir =  File.join(import_directory, locale)
+
+      Dir.mkdir(language_dir) unless Dir.exists?(language_dir)
+
+      import_yml_path = File.join(import_directory, locale, "#{group[0]}.yml")
+      import_csv(group[1], import_yml_path)
+    end
+  end
+
+  def group_csv_by_file(csv)
+    csv.group_by { |row| row["key"].split(".").first }
   end
 end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -30,14 +30,15 @@ namespace :translation do
   end
 
   desc "Import a specific locale CSV to YAML within the app."
-  task :import, [:csv_path] => [:environment] do |t, args|
+  task :import, [:csv_path, :multiple_files_per_language] => [:environment] do |t, args|
     import_dir = Rails.root.join("config", "locales")
     csv_path = args[:csv_path]
 
     importer = RailsTranslationManager::Importer.new(
       locale: File.basename(args[:csv_path], ".csv"),
       csv_path: csv_path,
-      import_directory: Rails.root.join("config", "locales")
+      import_directory: Rails.root.join("config", "locales"),
+      multiple_files_per_language: args[:multiple_files_per_language] || false
     )
     importer.import
 
@@ -46,7 +47,7 @@ namespace :translation do
 
   namespace :import do
     desc "Import all locale CSV files to YAML within the app."
-    task :all, [:csv_directory] => [:environment] do |t, args|
+    task :all, [:csv_directory, :multiple_files_per_language] => [:environment] do |t, args|
       directory = args[:csv_directory] || "tmp/locale_csv"
       import_dir = Rails.root.join("config", "locales")
 
@@ -55,6 +56,7 @@ namespace :translation do
           locale: File.basename(csv_path, ".csv"),
           csv_path: csv_path,
           import_directory: import_dir,
+          multiple_files_per_language: args[:multiple_files_per_language] || false
         )
         importer.import
       end

--- a/spec/rails_translation_manager/importer_spec.rb
+++ b/spec/rails_translation_manager/importer_spec.rb
@@ -3,48 +3,79 @@ require "tmpdir"
 
 RSpec.describe RailsTranslationManager::Importer do
   let(:import_directory) { Dir.mktmpdir }
-  let(:yaml_translation_data) { YAML.load_file(import_directory + "/fr.yml")["fr"] }
 
-  before do
-    importer = described_class.new(
-      locale: :fr,
-      csv_path: "spec/locales/importer/fr.csv",
-      import_directory: import_directory
-    )
-    importer.import
+  context "when there is one locale file per language" do
+    let(:yaml_translation_data) { YAML.load_file(import_directory + "/fr.yml")["fr"] }
+
+    before do
+      importer = described_class.new(
+        locale: "fr",
+        csv_path: "spec/locales/importer/fr.csv",
+        import_directory: import_directory,
+        multiple_files_per_language: false
+      )
+      importer.import
+    end
+
+    it "creates one YAML file per language" do
+      expect(File).to exist(import_directory + "/fr.yml")
+    end
+
+    it "imports nested locales" do
+      expected = { "type" => { "country" => "Pays" } }
+      expect(yaml_translation_data).to include("world_location" => hash_including(expected))
+    end
+
+    it "imports arrays from CSV as arrays" do
+      expected =  { "fruit" => ["Pommes", "Bananes", "Poires"] }
+      expect(yaml_translation_data).to include("world_location" => hash_including(expected))
+    end
+
+    it "imports string 'nil' as nil" do
+      expected = { "things" => nil }
+      expect(yaml_translation_data).to include("world_location" => hash_including(expected))
+    end
+
+    it "imports string ':thing' as symbol" do
+      expected = { "sentiment" => :bof }
+      expect(yaml_translation_data).to include("world_location" => hash_including(expected))
+    end
+
+    it "imports integer strings as integers" do
+      expected = { "price" => 123 }
+      expect(yaml_translation_data).to include("shared" => hash_including(expected))
+    end
+
+    it "imports boolean values as booleans, not strings" do
+      expected = { "key1" => true, "key2" => false }
+      expect(yaml_translation_data).to include("shared" => hash_including(expected))
+    end
   end
 
-  it "creates one YAML file per language" do
-    expect(File).to exist(import_directory + "/fr.yml")
-  end
+  context "when there are multiple files per locale" do
+    before do
+      importer = described_class.new(
+        locale: "fr",
+        csv_path: "spec/locales/importer/fr.csv",
+        import_directory: import_directory,
+        multiple_files_per_language: true
+      )
+      importer.import
+    end
 
-  it "imports nested locales" do
-    expected = { "type" => { "country" => "Pays" } }
-    expect(yaml_translation_data).to include("world_location" => hash_including(expected))
-  end
+    it "creates multiple YAML files per language in the language's directory" do
+      expect(File).to exist(import_directory + "/fr/world_location.yml")
+                  .and exist(import_directory + "/fr/shared.yml")
+    end
 
-  it "imports arrays from CSV as arrays" do
-    expected =  { "fruit" => ["Pommes", "Bananes", "Poires"] }
-    expect(yaml_translation_data).to include("world_location" => hash_including(expected))
-  end
+    it "imports only 'world_location' locales to the relevant file" do
+      yaml_translation_data = YAML.load_file(import_directory + "/fr/world_location.yml")["fr"]
+      expect(yaml_translation_data).to match("world_location" => anything)
+    end
 
-  it "imports string 'nil' as nil" do
-    expected = { "things" => nil }
-    expect(yaml_translation_data).to include("world_location" => hash_including(expected))
-  end
-
-  it "imports string ':thing' as symbol" do
-    expected = { "sentiment" => :bof }
-    expect(yaml_translation_data).to include("world_location" => hash_including(expected))
-  end
-
-  it "imports integer strings as integers" do
-    expected = { "price" => 123 }
-    expect(yaml_translation_data).to include("shared" => hash_including(expected))
-  end
-
-  it "imports boolean values as booleans, not strings" do
-    expected = { "key1" => true, "key2" => false }
-    expect(yaml_translation_data).to include("shared" => hash_including(expected))
+    it "imports only 'shared' locales to the relevant file" do
+      yaml_translation_data = YAML.load_file(import_directory + "/fr/shared.yml")["fr"]
+      expect(yaml_translation_data).to match("shared" => anything)
+    end
   end
 end

--- a/spec/tasks/translation_spec.rb
+++ b/spec/tasks/translation_spec.rb
@@ -26,7 +26,8 @@ describe "rake tasks" do
         .to have_received(:new)
         .with(locale: "fr",
               csv_path: csv_path,
-              import_directory: Rails.root.join("config", "locales"))
+              import_directory: Rails.root.join("config", "locales"),
+              multiple_files_per_language: false)
       expect(importer_instance).to have_received(:import)
     end
   end
@@ -43,13 +44,14 @@ describe "rake tasks" do
     end
 
     it "calls the importer class for each target path" do
-      task.execute(csv_directory: csv_directory)
+      task.execute(csv_directory: csv_directory, multiple_files_per_language: true)
 
       expect(RailsTranslationManager::Importer)
         .to have_received(:new)
         .with(locale: "fr",
               csv_path: "spec/locales/importer/fr.csv",
-              import_directory: Rails.root.join("config", "locales"))
+              import_directory: Rails.root.join("config", "locales"),
+              multiple_files_per_language: true)
       expect(importer_instance).to have_received(:import)
     end
   end


### PR DESCRIPTION
This PR adds the functionality to import nested locales from one
CSV. We need to do this for Collections but will work for any app with
nested locales, e.g: `config/locales/fr/some_file.yml`.

Tested this locally with nested and non-nested imports which were
both successful.

More info in the commits ->

---

Trello:
https://trello.com/c/k4rrt3UG/2686-update-csv-import-rails-translation-manager-3