### PR TITLE
Delete workspace on build start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,7 @@
 library("govuk")
 
 node {
-  govuk.buildProject()
+  govuk.buildProject(
+    cleanWorkspace: true,
+  )
 }


### PR DESCRIPTION
Fixes an issue whereby subsequent builds of any branch fail with
obscure messages along the lines of:
> error: wrong index v2 file size in .git/objects/pack/pack-b360de1f7cfbce9b7fa4b4c11ea4dc4daea3d1f7.idx

Depends on https://github.com/alphagov/govuk-jenkinslib/pull/91

Tested that this works in https://github.com/alphagov/rails_translation_manager/pull/22, by pushing several commits and seeing each build pass.

Trello: https://trello.com/c/Pq7ffzxM/2752-investigate-rails-translation-manager-failing-builds