### PR TITLE
Re-add import/export code

### DIFF
--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -13,6 +13,8 @@ require "rails_translation_manager/locale_checker/incompatible_plurals"
 require "rails_translation_manager/locale_checker/all_locales"
 require "rails_translation_manager/locale_checker"
 require "rails_translation_manager/cleaner"
+require "rails_translation_manager/exporter"
+require "rails_translation_manager/importer"
 
 module RailsTranslationManager
   rails_i18n_path = Gem::Specification.find_by_name("rails-i18n").gem_dir

--- a/lib/rails_translation_manager/exporter.rb
+++ b/lib/rails_translation_manager/exporter.rb
@@ -1,0 +1,111 @@
+# encoding: utf-8
+require "yaml"
+require "csv"
+require 'i18n'
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/hash/keys.rb"
+
+class RailsTranslationManager::Exporter
+  def initialize(directory, source_locale_path, target_locale_path)
+    @source_locale_path = source_locale_path
+    @target_locale_path = target_locale_path
+    @source_locale = File.basename(target_locale_path).split(".")[0]
+    @target_locale = File.basename(target_locale_path).split(".")[0]
+    @output_path = File.join(directory, @target_locale + ".csv")
+
+    @keyed_source_data = translation_file_to_keyed_data(source_locale_path, @source_locale)
+    @keyed_target_data = translation_file_to_keyed_data(target_locale_path, @target_locale)
+  end
+
+  def export
+    csv = CSV.generate do |csv|
+      csv << CSV::Row.new(["key", "source", "translation"], ["key", "source", "translation"], true)
+      @keyed_source_data.keys.sort.each do |key|
+        if key =~ /^language_names\./
+          next unless key =~ /#{@target_locale}$/
+        end
+        if is_pluralized_key?(key)
+          export_pluralization_rows(key, csv)
+        else
+          csv << export_row(key, @keyed_source_data[key], @keyed_target_data[key])
+        end
+      end
+    end
+    File.open(@output_path, "w") { |f| f.write csv.to_s }
+  end
+
+  private
+
+  def export_pluralization_rows(key, csv)
+    I18n.t('i18n.plural.keys', locale: @target_locale).map(&:to_s).each do |plural_key|
+      csv << export_row(depluralized_key_for(key, plural_key), @keyed_source_data.fetch(key, {})[plural_key], @keyed_target_data.fetch(key, {})[plural_key])
+    end
+  end
+
+  def export_row(key, source_value, target_value)
+    CSV::Row.new(['key', 'source', 'translation'], [key, source_value, target_value])
+  end
+
+  def translation_file_to_keyed_data(path, locale)
+    if File.exist?(path)
+      hash = YAML.load_file(path).values[0]
+      hash_to_keyed_data("", hash, locale)
+    else
+      {}
+    end
+  end
+
+  def hash_to_keyed_data(prefix, hash, locale)
+    if hash_is_for_pluralization?(hash, locale)
+      {pluralized_prefix(prefix) => hash.stringify_keys}
+    else
+      results = {}
+      hash.each do |key, value|
+        if value.is_a?(Hash)
+          results.merge!(hash_to_keyed_data(key_for(prefix, key), value, locale))
+        else
+          results[key_for(prefix, key)] = value
+        end
+      end
+      results
+    end
+  end
+
+  # if the hash is only made up of the plural keys for the locale, we
+  # assume it's a plualization set.  Note that zero is *always* an option
+  # regardless of the keys fetched
+  # (see https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/pluralization.rb#L34)
+  def hash_is_for_pluralization?(hash, locale)
+    plural_keys = I18n.t('i18n.plural.keys', locale: locale)
+    raise missing_pluralisations_message(locale) unless plural_keys.is_a?(Array)
+    ((hash.keys.map(&:to_s) - plural_keys.map(&:to_s)) - ['zero']).empty?
+  end
+
+  def missing_pluralisations_message(locale)
+    "No pluralization forms defined for locale '#{locale}'. " +
+    "This probably means that the rails-18n gem does not provide a " +
+    "definition of the plural forms for this locale, you may need to " +
+    "define them yourself."
+  end
+
+  def key_for(prefix, key)
+    prefix.blank? ? key.to_s : "#{prefix}.#{key}"
+  end
+
+  def is_pluralized_key?(key)
+    key =~ /\APLURALIZATION\-KEY\:/
+  end
+
+  def pluralized_prefix(prefix)
+    if is_pluralized_key?(prefix)
+      prefix
+    else
+      "PLURALIZATION-KEY:#{prefix}"
+    end
+  end
+
+  def depluralized_key_for(prefix, key)
+    depluralized_prefix = prefix.gsub(/\APLURALIZATION\-KEY\:/, '')
+    key_for(depluralized_prefix, key)
+  end
+end

--- a/lib/rails_translation_manager/importer.rb
+++ b/lib/rails_translation_manager/importer.rb
@@ -1,0 +1,58 @@
+require "yaml"
+require "csv"
+require_relative "yaml_writer"
+
+class RailsTranslationManager::Importer
+  include YAMLWriter
+
+  def initialize(locale, csv_path, import_directory)
+    @csv_path = csv_path
+    @locale = locale
+    @import_directory = import_directory
+  end
+
+  def import
+    csv = CSV.read(@csv_path, headers: true, header_converters: :downcase)
+    data = {}
+    csv.each do |row|
+      key = row["key"]
+      key_parts = key.split(".")
+      if key_parts.length > 1
+        leaf_node = (data[key_parts.first] ||= {})
+        key_parts[1..-2].each do |part|
+          leaf_node = (leaf_node[part] ||= {})
+        end
+        leaf_node[key_parts.last] = parse_translation(row["translation"])
+      else
+        data[key_parts.first] = parse_translation(row["translation"])
+      end
+    end
+
+    write_yaml(import_yml_path, {@locale.to_s => data})
+  end
+
+  private
+
+  def import_yml_path
+    File.join(@import_directory, "#{@locale}.yml")
+  end
+
+  def parse_translation(translation)
+    if translation =~ /^\[/
+      values = translation.gsub(/^\[/, '').gsub(/\]$/, '').gsub("\"", '').split(/\s*,\s*/)
+      values.map { |v| parse_translation(v) }
+    elsif translation =~ /^:/
+      translation.gsub(/^:/, '').to_sym
+    elsif translation =~ /^true$/
+      true
+    elsif translation =~ /^false$/
+      false
+    elsif translation =~ /^\d+$/
+      translation.to_i
+    elsif translation == "nil"
+      nil
+    else
+      translation
+    end
+  end
+end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -4,6 +4,49 @@ require_relative "../tasks/translation_helper"
 
 namespace :translation do
 
+  desc "Export a specific locale to CSV."
+  task :export, [:directory, :base_locale, :target_locale] => [:environment] do |t, args|
+    FileUtils.mkdir_p(args[:directory]) unless File.exist?(args[:directory])
+    base_locale = Rails.root.join("config", "locales", args[:base_locale] + ".yml")
+    target_locale_path = Rails.root.join("config", "locales", args[:target_locale] + ".yml")
+    exporter = RailsTranslationManager::Exporter.new(args[:directory], base_locale, target_locale_path)
+    exporter.export
+  end
+
+  namespace :export do
+    desc "Export all locales to CSV files."
+    task :all, [:directory] => [:environment] do |t, args|
+      directory = args[:directory] || "tmp/locale_csv"
+      FileUtils.mkdir_p(directory) unless File.exist?(directory)
+      locales = Dir[Rails.root.join("config", "locales", "*.yml")]
+      base_locale = Rails.root.join("config", "locales", "en.yml")
+      target_locales = locales - [base_locale.to_s]
+      target_locales.each do |target_locale_path|
+        exporter = RailsTranslationManager::Exporter.new(directory, base_locale, target_locale_path)
+        exporter.export
+      end
+      puts "Exported locale CSV to #{directory}"
+    end
+  end
+
+  desc "Import a specific locale CSV to YAML within the app."
+  task :import, [:locale, :path] => [:environment] do |t, args|
+    importer = RailsTranslationManager::Importer.new(args[:locale], args[:path], Rails.root.join("config", "locales"))
+    importer.import
+  end
+
+  namespace :import do
+    desc "Import all locale CSV files to YAML within the app."
+    task :all, [:directory] => [:environment] do |t, args|
+      directory = args[:directory] || "tmp/locale_csv"
+      Dir[File.join(directory, "*.csv")].each do |csv_path|
+        locale = File.basename(csv_path, ".csv")
+        importer = RailsTranslationManager::Importer.new(locale, csv_path, Rails.root.join("config", "locales"))
+        importer.import
+      end
+    end
+  end
+
   desc "Add missing translations"
   task(:add_missing, [:locale] => [:environment]) do |t, args|
     I18n::Tasks::CLI.start(TranslationHelper.new(["add-missing", "--nil-value"], args[:locale]).with_optional_locale)

--- a/test/rails_translation_manager/exporter_test.rb
+++ b/test/rails_translation_manager/exporter_test.rb
@@ -1,0 +1,239 @@
+require "test_helper"
+
+require "rails_translation_manager/exporter"
+require "tmpdir"
+require "csv"
+require "i18n"
+
+module RailsTranslationManager
+  class ExporterTest < Minitest::Test
+
+    def setup
+      # fast test helper means we have to setup the pluralizations we're
+      # going to use manually as rails-i18n does it in the rails app
+      I18n.backend.class.send(:include, I18n::Backend::Pluralization)
+      I18n.available_locales = [:fr, :es, :ar, :sk, :uk]
+      with_pluralization_forms(
+        'fr' => [:one, :other],
+        'es' => [:one, :other],
+        'ar' => [:zero, :one, :two, :few, :many, :other],
+        'sk' => [:one, :few, :other],
+        'uk' => [:one, :few, :many, :other]
+      )
+    end
+
+    test 'should export CSV file for filling in a given translation' do
+      given_locale(:en, {
+        world_location: {
+          type: {
+            country: "Country"
+          },
+          country: "Spain",
+          headings: {
+            mission: "Our mission",
+            offices: "Offices"
+          }
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:fr)).export
+
+      assert File.file?(exported_file("fr.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("fr.csv"))
+      assert_equal ["Country", nil], data["world_location.type.country"]
+      assert_equal ["Spain", nil], data["world_location.country"]
+      assert_equal ["Our mission", nil], data["world_location.headings.mission"]
+      assert_equal ["Offices", nil], data["world_location.headings.offices"]
+    end
+
+    test 'should include any existing translations in the output file' do
+      given_locale(:en, {
+        world_location: {
+          type: {
+            country: "Country"
+          },
+          country: "Spain",
+          headings: {
+            mission: "Our mission",
+            offices: "Offices"
+          }
+        }
+      })
+      given_locale(:fr, {
+        world_location: {
+          type: {
+            country: "Pays"
+          },
+          country: "Espange"
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:fr)).export
+
+      assert File.file?(exported_file("fr.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("fr.csv"))
+      assert_equal ["Country", "Pays"], data["world_location.type.country"]
+      assert_equal ["Spain", "Espange"], data["world_location.country"]
+      assert_equal ["Our mission", nil], data["world_location.headings.mission"]
+      assert_equal ["Offices", nil], data["world_location.headings.offices"]
+    end
+
+    test 'should not include any language names that are not English or the native in the output file' do
+      given_locale(:en, {
+        language_names: {
+          en: "English",
+          es: "Spanish",
+          fr: "French"
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:fr)).export
+
+      assert File.file?(exported_file("fr.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("fr.csv"))
+      assert_equal ["French", nil], data["language_names.fr"]
+      assert_equal nil, data["language_names.es"], "language key for spanish should not be present"
+    end
+
+    test 'should export correct pluralization forms for target' do
+      given_locale(:en, {
+        ministers: {
+          one: 'minister',
+          other: 'ministers'
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:ar)).export
+
+      assert File.file?(exported_file("ar.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("ar.csv"))
+      ['zero', 'one', 'two', 'few', 'many', 'other'].each do |arabic_plural_form|
+        assert data.has_key?("ministers.#{arabic_plural_form}"), "expected plural form #{arabic_plural_form} to be present, but it's not"
+      end
+    end
+
+    test 'should export source pluralization forms values to target when the forms match' do
+      given_locale(:en, {
+        ministers: {
+          one: 'minister',
+          other: 'ministers'
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:sk)).export
+
+      assert File.file?(exported_file("sk.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("sk.csv"))
+      assert_equal ['minister', nil], data['ministers.one']
+      assert_equal ['ministers', nil], data['ministers.other']
+      assert_equal [nil, nil], data['ministers.few']
+    end
+
+    test 'should keep existing target pluralization form values' do
+      given_locale(:en, {
+        ministers: {
+          one: 'minister',
+          other: 'ministers'
+        }
+      })
+      given_locale(:sk, {
+        ministers: {
+          one: 'min',
+          few: 'mini'
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:sk)).export
+
+      assert File.file?(exported_file("sk.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("sk.csv"))
+      assert_equal ['minister', 'min'], data['ministers.one']
+      assert_equal ['ministers', nil], data['ministers.other']
+      assert_equal [nil, 'mini'], data['ministers.few']
+    end
+
+    test 'should allow for zero keys when detecting pluralization forms' do
+      given_locale(:en, {
+        ministers: {
+          zero: 'no ministers',
+          one: 'minister',
+          other: 'ministers'
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:uk)).export
+
+      assert File.file?(exported_file("uk.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("uk.csv"))
+      ['one', 'few', 'many', 'other'].each do |ukranian_plural_form|
+        assert data.has_key?("ministers.#{ukranian_plural_form}"), "expected plural form #{ukranian_plural_form} to be present, but it's not"
+      end
+    end
+
+    test 'should leave keys alone if the hash doesn\'t look like it only contains pluralization forms' do
+      given_locale(:en, {
+        ministers: {
+          one: 'minister',
+          other: 'ministers',
+          monkey: 'monkey'
+        }
+      })
+
+      Exporter.new(export_directory, locale_path(:en), locale_path(:uk)).export
+
+      assert File.file?(exported_file("uk.csv")), "should write a file"
+
+      data = read_csv_data(exported_file("uk.csv"))
+      ['few', 'many'].each do |ukranian_plural_form|
+        refute data.has_key?("ministers.#{ukranian_plural_form}"), "expected plural form #{ukranian_plural_form} to be missing, but it's present"
+      end
+      ['one', 'other', 'monkey'].each do |non_plural_forms|
+        assert data.has_key?("ministers.#{non_plural_forms}"), "expected non-plural form #{non_plural_forms} to be present, but it's not"
+      end
+    end
+
+  private
+
+    def read_csv_data(file)
+      csv = CSV.read(file, headers: true)
+      csv.inject({}) { |h, row| h[row["key"]] = [row["source"], row["translation"]]; h }
+    end
+
+    def given_locale(locale, keys)
+      File.open(locale_path(locale), "w") do |f|
+        f.puts({locale => keys}.to_yaml)
+      end
+    end
+
+    def locale_path(locale)
+      File.join(export_directory, "#{locale}.yml")
+    end
+
+    def exported_file(name)
+      File.new(File.join(export_directory, name))
+    end
+
+    def export_directory
+      @tmpdir ||= Dir.mktmpdir
+    end
+
+    def with_pluralization_forms(pluralizations)
+      pluralizations.each do |locale, pluralization_forms|
+        I18n.backend.store_translations(locale, {
+          'i18n' => {
+            'plural' => {
+              'keys' => pluralization_forms
+            }
+          }
+        })
+      end
+    end
+  end
+end

--- a/test/rails_translation_manager/importer_test.rb
+++ b/test/rails_translation_manager/importer_test.rb
@@ -1,0 +1,132 @@
+require "test_helper"
+require "rails_translation_manager/importer"
+require "tmpdir"
+require "csv"
+
+module RailsTranslationManager
+  class ImporterTest < Minitest::Test
+    test 'should create a new locale file for a filled in translation csv file' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["world_location.type.country", "Country", "Pays"],
+        ["world_location.country", "Germany", "Allemange"],
+        ["other.nested.key", "original", "translated"]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "world_location" => {
+          "country" => "Allemange",
+          "type" => {
+            "country" => "Pays"
+          }
+        },
+        "other" => {
+          "nested" => {
+            "key" => "translated"
+          }
+        }
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+    test 'imports arrays from CSV as arrays' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["fruit", ["Apples", "Bananas", "Pears"], ["Pommes", "Bananes", "Poires"]]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "fruit" => ["Pommes", "Bananes", "Poires"]
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+    test 'interprets string "nil" as nil' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["things", ["one", nil, "two"], ["une", nil, "deux"]]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "things" => ["une", nil, "deux"]
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+    test 'interprets string ":thing" as symbol' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["sentiment", ":whatever", ":bof"]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "sentiment" => :bof
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+    test 'interprets integer strings as integers' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["price", "123", "123"]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "price" => 123
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+    test 'interprets boolean values as booleans, not strings' do
+      given_csv(:fr,
+        [:key, :source, :translation],
+        ["key1", "is true", "true"],
+        ["key2", "is false", "false"]
+      )
+
+      Importer.new(:fr, csv_path(:fr), import_directory).import
+
+      yaml_translation_data = YAML.load_file(File.join(import_directory, "fr.yml"))
+      expected = {"fr" => {
+        "key1" => true,
+        "key2" => false
+      }}
+      assert_equal expected, yaml_translation_data
+    end
+
+  private
+
+    def csv_path(locale)
+      File.join(import_directory, "#{locale}.csv")
+    end
+
+    def given_csv(locale, header_row, *rows)
+      csv = CSV.generate do |csv|
+        csv << CSV::Row.new(["key", "source", "translation"], ["key", "source", "translation"], true)
+        rows.each do |row|
+          csv << CSV::Row.new(["key", "source", "translation"], row)
+        end
+      end
+      File.open(csv_path(locale), "w") { |f| f.write csv.to_s }
+    end
+
+    def import_directory
+      @import_directory ||= Dir.mktmpdir
+    end
+  end
+end


### PR DESCRIPTION
These tasks were mistakenly removed in [1] and are needed so we can import and export locales. This PR simply reverts that change which https://github.com/alphagov/rails_translation_manager/pull/18 then refactors.

[1]: https://github.com/alphagov/rails_translation_manager/pull/21/commits/39a7cbfb7beedc60a5fedb15671f8928cfaa6110