### PR TITLE
Rename class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+Fix Rails Translation Manager / Rails naming clash for class. https://github.com/alphagov/rails_translation_manager/pull/26
+
 ## 1.1.0
 
 Allow multiple files per language to be imported. https://github.com/alphagov/rails_translation_manager/pull/20

--- a/lib/rails_translation_manager/i18n_tasks_option_parser.rb
+++ b/lib/rails_translation_manager/i18n_tasks_option_parser.rb
@@ -1,5 +1,4 @@
-class TranslationHelper
-
+class RailsTranslationManager::I18nTasksOptionParser
   def initialize(task_options, locale)
     @task_options = task_options
     @locale = locale

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -1,6 +1,6 @@
-require "rails_translation_manager"
 require "i18n/tasks/cli"
-require_relative "../tasks/translation_helper"
+require_relative "../rails_translation_manager"
+require_relative "../rails_translation_manager/i18n_tasks_option_parser"
 
 namespace :translation do
 
@@ -67,13 +67,21 @@ namespace :translation do
 
   desc "Add missing translations"
   task(:add_missing, [:locale] => [:environment]) do |t, args|
-    I18n::Tasks::CLI.start(TranslationHelper.new(["add-missing", "--nil-value"], args[:locale]).with_optional_locale)
+    option_parser = RailsTranslationManager::I18nTasksOptionParser.new(
+      ["add-missing", "--nil-value"], args[:locale]
+    ).with_optional_locale
+
+    I18n::Tasks::CLI.start(option_parser)
     RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 
   desc "Normalize translations"
   task(:normalize, [:locale] => [:environment]) do |t, args|
-    I18n::Tasks::CLI.start(TranslationHelper.new(["normalize"], args[:locale]).with_optional_locale)
+    option_parser = RailsTranslationManager::I18nTasksOptionParser.new(
+      ["normalize"], args[:locale]
+    ).with_optional_locale
+
+    I18n::Tasks::CLI.start(option_parser)
     RailsTranslationManager::Cleaner.new(Rails.root.join("config", "locales")).clean
   end
 end


### PR DESCRIPTION
The class `TranslationHelper` was causing some strange errors to occur
in one the apps (Whitehall) that bundle Rails Translation Manager.

The error that was produced when running rake (in Whitehall):

```
TypeError: wrong argument type Class (expected Module)
/govuk/whitehall/test/test_helper.rb:300:in `<main>'
/govuk/whitehall/test/functional/admin/about_pages_controller_test.rb:1:in `<main>'
/root/.rbenv/versions/2.6.6/bin/bundle:23:in `load'
/root/.rbenv/versions/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => test
```

This error message wasn't very clear, and so by stepping through the
code in RTM it appears the class `TranslationHelper` was causing the
issue. Not sure exactly why, but I assume it's because Rails already
defines `TranslationHelper` as a module [1].

As part of this I've renamed the class and moved it to where the rest of
the ruby scripts are defined.

Original Whitehall bump attempt:
https://github.com/alphagov/whitehall/pull/6355

[1]: https://api.rubyonrails.org/v5.1.7/classes/ActionView/Helpers/TranslationHelper.html