### PR TITLE
Handle BOM from import files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+Handle importing files that contain Byte Order Marks. https://github.com/alphagov/rails_translation_manager/pull/27
+
 ## 1.1.1
 
 Fix Rails Translation Manager / Rails naming clash for class. https://github.com/alphagov/rails_translation_manager/pull/26

--- a/lib/rails_translation_manager/importer.rb
+++ b/lib/rails_translation_manager/importer.rb
@@ -15,7 +15,7 @@ class RailsTranslationManager::Importer
   end
 
   def import
-    csv = CSV.read(csv_path, headers: true, header_converters: :downcase)
+    csv = CSV.read(csv_path, encoding: "bom|utf-8", headers: true, header_converters: :downcase)
 
     multiple_files_per_language ? import_csv_into_multiple_files(csv) : import_csv(csv)
   end

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/rails_translation_manager.gemspec
+++ b/rails_translation_manager.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails-i18n"
   spec.add_dependency "activesupport"
+  spec.add_dependency "csv", "~> 3.2"
   spec.add_dependency "i18n-tasks"
+  spec.add_dependency "rails-i18n"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/locales/importer/hy_with_byte_order_mark.csv
+++ b/spec/locales/importer/hy_with_byte_order_mark.csv
@@ -1,0 +1,4 @@
+﻿key,source,translation
+unpublishing.title,The page you're looking for is no longer available,Ձեր փնտրած էջն այլևս հասանելի չէ
+working_group.contact_details,Contact details,Կոնտակտային տվյալներ
+working_group.policies,Policies,Քաղաքականություններ

--- a/spec/rails_translation_manager/importer_spec.rb
+++ b/spec/rails_translation_manager/importer_spec.rb
@@ -4,6 +4,18 @@ require "tmpdir"
 RSpec.describe RailsTranslationManager::Importer do
   let(:import_directory) { Dir.mktmpdir }
 
+  it "imports CSV containing a byte order mark" do
+    importer = described_class.new(
+      locale: "hy",
+      csv_path: "spec/locales/importer/hy_with_byte_order_mark.csv",
+      import_directory: import_directory,
+      multiple_files_per_language: false
+    )
+    importer.import
+
+    expect(File).to exist(import_directory + "/hy.yml")
+  end
+
   context "when there is one locale file per language" do
     let(:yaml_translation_data) { YAML.load_file(import_directory + "/fr.yml")["fr"] }
 

--- a/spec/tasks/translation_spec.rb
+++ b/spec/tasks/translation_spec.rb
@@ -45,14 +45,18 @@ describe "rake tasks" do
 
     it "calls the importer class for each target path" do
       task.execute(csv_directory: csv_directory, multiple_files_per_language: true)
+      import_paths = Dir["spec/locales/importer/*.csv"]
 
-      expect(RailsTranslationManager::Importer)
-        .to have_received(:new)
-        .with(locale: "fr",
-              csv_path: "spec/locales/importer/fr.csv",
-              import_directory: Rails.root.join("config", "locales"),
-              multiple_files_per_language: true)
-      expect(importer_instance).to have_received(:import)
+      import_paths.each do |csv_path|
+        expect(RailsTranslationManager::Importer)
+          .to have_received(:new)
+          .with(locale: File.basename(csv_path, ".csv"),
+                csv_path: csv_path,
+                import_directory: Rails.root.join("config", "locales"),
+                multiple_files_per_language: true)
+      end
+
+      expect(importer_instance).to have_received(:import).exactly(import_paths.count)
     end
   end
 


### PR DESCRIPTION
Byte order marks [1] can exist on CSVs we try and import. Natively,
they're not recognised by Ruby's CSV library and cause confusing errors.

This PR handles importing files with BOMs.

More info in the commits ->

---

Trello:
https://trello.com/c/PNKIk1zZ/2526-automatically-strip-bom-from-csvs-before-importing

[1]: https://en.wikipedia.org/wiki/Byte_order_mark