### PR TITLE
Add a skip_validation parameter to LocaleChecker in order to exclude false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+Add `skip_validation` parameter to `LocaleChecker`. https://github.com/alphagov/rails_translation_manager/pull/35
+
 ## 1.3.0
 
 Add remove-unused task wrapper. https://github.com/alphagov/rails_translation_manager/pull/32

--- a/lib/rails_translation_manager/locale_checker.rb
+++ b/lib/rails_translation_manager/locale_checker.rb
@@ -10,8 +10,9 @@ module RailsTranslationManager
                        MissingForeignLocales,
                        UndeclaredLocaleFiles].freeze
 
-    def initialize(locale_path)
+    def initialize(locale_path, skip_validation = [])
       @locale_path = locale_path
+      @skip_validation = skip_validation
     end
 
     def validate_locales
@@ -21,7 +22,7 @@ module RailsTranslationManager
       false
     end
 
-    private
+  private
 
     def output_result
       errors = checker_errors.compact
@@ -46,7 +47,7 @@ module RailsTranslationManager
     end
 
     def all_locales
-      @all_locales ||= AllLocales.new(locale_path).generate
+      @all_locales ||= AllLocales.new(locale_path, @skip_validation).generate
     end
   end
 end

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/spec/rails_translation_manager/locale_checker/all_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/all_locales_spec.rb
@@ -21,4 +21,28 @@ RSpec.describe AllLocales do
         .to raise_error(AllLocales::NoLocaleFilesFound, 'No locale files found for the supplied path')
     end
   end
+  
+  context "when some keys are excluded" do
+    it "generates an array of hashes without those keys" do
+      expect(described_class.new("spec/locales/out_of_sync/*.yml", skip_validation = %w{wrong_plural.one}).generate)
+        .to eq(
+          [
+            { keys: %w[test wrong_plural wrong_plural.zero], locale: :en },
+            { keys: %w[other_test], locale: :cy }
+          ]
+      )
+    end
+  end
+
+  context "when a key prefix is excluded" do
+    it "generates an array of hashes without those keys" do
+      expect(described_class.new("spec/locales/out_of_sync/*.yml", skip_validation = %w{wrong_plural}).generate)
+        .to eq(
+          [
+            { keys: %w[test], locale: :en },
+            { keys: %w[other_test], locale: :cy }
+          ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
In some cases the LocaleChecker produces false positives: in collections ([#2651](https://github.com/alphagov/collections/pull/2651)) because the key `other` is wrongly interpreted as a plural, and in frontend because the structure of the translation files is non-standard.

This allows passing an array of keys (or key prefixes) when instantiating the checker.

https://trello.com/c/faHEHUr8/2827-apply-locale-file-validation-to-collections
https://trello.com/c/MMvOpCC4/2826-apply-locale-file-validation-to-frontend
