### PR TITLE
Add plurals dropped from rails-i18n in 7.0.6

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 {
+  # Welsh
+  cy: { i18n: { plural: { keys: %i[zero one two few many other],
+                          rule:
+                            lambda do |n|
+                              case n
+                              when 0 then :zero
+                              when 1 then :one
+                              when 2 then :two
+                              when 3 then :few
+                              when 6 then :many
+                              else :other
+                              end
+                            end } } },
   # Dari - this isn't an iso code. Probably should be 'prs' as per ISO 639-3.
   dr: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Latin America and Caribbean Spanish


### PR DESCRIPTION
The 7.0.6 release of rails-i18n dropped support for a number of plurals [1] and this causes our apps that make use of these languages to error and thus be unable to update to rails-i18n 7.0.6

This commit ports over these rules from rails-i18n to maintain the behaviour.

This update follows what was added into govuk_app_config [2]

[1]: https://github.com/svenfuchs/rails-i18n/pull/1017
[2]: https://github.com/alphagov/govuk_app_config/pull/266