### PR TITLE
Update plural rules loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Update plural file loading https://github.com/alphagov/rails_translation_manager/pull/52
+
 # 1.5.2
 
 Add missing plurals for Gujarati and Yiddish https://github.com/alphagov/rails_translation_manager/pull/44

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -20,13 +20,9 @@ require "rails_translation_manager/exporter"
 require "rails_translation_manager/importer"
 
 module RailsTranslationManager
-  rails_i18n_path = Gem::Specification.find_by_name("rails-i18n").gem_dir
   rails_translation_manager = Gem::Specification.find_by_name("rails_translation_manager").gem_dir
 
-  I18n.load_path.concat(
-    Dir["#{rails_i18n_path}/rails/pluralization/*.rb"],
-    ["#{rails_translation_manager}/config/locales/plurals.rb"]
-  )
+  I18n.load_path += ["#{rails_translation_manager}/config/locales/plurals.rb"]
 
   def self.locale_root
     if ENV["RAILS_TRANSLATION_MANAGER_LOCALE_ROOT"]

--- a/lib/rails_translation_manager/locale_checker/plural_forms.rb
+++ b/lib/rails_translation_manager/locale_checker/plural_forms.rb
@@ -4,7 +4,7 @@ class PluralForms
   def self.all
     I18n.available_locales.each_with_object({}) do |locale, hsh|
       begin
-        # fetches plural form (rule) from rails-i18n for locale
+        # fetches plural form (rule) from rails-i18n or config/locales/plurals.rb for locale
         plural_form = I18n.with_locale(locale) { I18n.t!("i18n.plural.keys") }.sort
       rescue I18n::MissingTranslationData
         plural_form = nil

--- a/spec/rails_translation_manager/locale_checker/plural_forms_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/plural_forms_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe PluralForms do
     end
 
     it "returns nil for associated locales" do
+      # clears any in-memory translations
+      I18n.backend.reload!
+
       expect(described_class.all).to include({ cy: nil, en: nil })
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,24 @@ RSpec.configure do |config|
   config.before do
     I18n.available_locales = %i[en cy]
     config.before { allow($stdout).to receive(:puts) }
+    I18n.backend.store_translations :en, i18n: { plural: { keys: %i[one other],
+                                                           rule:
+                                                             lambda do |n|
+                                                               n == 1 ? :one : :other
+                                                             end } }
+    I18n.backend.store_translations :cy, i18n: { plural: { keys: %i[zero one two few many other],
+                                                           rule:
+                                                             lambda do |n|
+                                                               case n
+                                                               when 0 then :zero
+                                                               when 1 then :one
+                                                               when 2 then :two
+                                                               when 3 then :few
+                                                               when 6 then :many
+                                                               else :other
+                                                               end
+                                                             end } }
+
   end
 
   def capture_stdout(&blk)


### PR DESCRIPTION
Previously, pluralization files for all locales would be added to I18n's load path (from `rails-i18n`). However, some frontend applications only support limited locales so bulk adding them is unnecessary. The relevant plural rules (dervived from `available_locales`) are also added when I18n initialises in RoR apps which removes the need to add them manually via RTM.

Testing on Frontend, this reduced the amount of files in I18n's load path from 226 to 75.

This commit also favours using in-memory pluralisation translations for local testing, rather than pulling them in from `rails-i18n`.