### PR TITLE
Update missing English keys checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 Update plural file loading https://github.com/alphagov/rails_translation_manager/pull/52
+Update missing English keys checker https://github.com/alphagov/rails_translation_manager/pull/53
 
 # 1.5.2
 

--- a/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
+++ b/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
@@ -13,10 +13,10 @@ class MissingEnglishLocales < BaseChecker
 
   def format_missing_english_locales(keys)
     formatted_keys = keys.to_a.map do |group|
-      "\e[1mMissing English keys:\e[22m #{group[0]}\n\e[1mFound in:\e[22m #{group[1]}"
+      "\e[1mMissing English locales:\e[22m #{group[0]}\n\e[1mFound in:\e[22m #{group[1]}"
     end
 
-    "\e[31m[ERROR]\e[0m Missing English locales, either remove these keys from the foreign locales or add them to the English locales\n\n#{formatted_keys.join("\n\n")}"
+    "\e[31m[ERROR]\e[0m Missing English locales, either remove them from the foreign locale files or add them to the English locale files\n\n#{formatted_keys.join("\n\n")}"
   end
 
   def missing_english_locales

--- a/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
+++ b/lib/rails_translation_manager/locale_checker/missing_english_locales.rb
@@ -20,12 +20,16 @@ class MissingEnglishLocales < BaseChecker
   end
 
   def missing_english_locales
-    all_locales.each_with_object({}) do |locale, hsh|
-      missing_keys = exclude_plurals(locale[:keys]) - english_keys_excluding_plurals(all_locales)
+    all_locales.each_with_object({}) do |group, hsh|
+      next if group[:locale] == :en
+
+      keys = exclude_plurals(group[:keys])
+
+      missing_keys = keys.reject { |key| I18n.exists?(key) }
 
       next if missing_keys.blank?
 
-      hsh[locale[:locale]] = missing_keys
+      hsh[group[:locale]] = missing_keys
     end
   end
 end

--- a/spec/locales/in_sync/en/browse.yml
+++ b/spec/locales/in_sync/en/browse.yml
@@ -1,5 +1,5 @@
 ---
-cy:
+en:
   in_sync:
     key: food
     second_key: cat

--- a/spec/rails_translation_manager/importer_spec.rb
+++ b/spec/rails_translation_manager/importer_spec.rb
@@ -32,73 +32,81 @@ RSpec.describe RailsTranslationManager::Importer do
   context "when there is one locale file per language" do
     let(:yaml_translation_data) { YAML.load_file(import_directory + "/fr.yml")["fr"] }
 
-    before do
-      importer = described_class.new(
+    let(:importer) do
+      described_class.new(
         locale: "fr",
         csv_path: "spec/locales/importer/fr.csv",
         import_directory: import_directory,
         multiple_files_per_language: false
       )
-      importer.import
     end
 
     it "creates one YAML file per language" do
+      expect { importer.import }.to output.to_stdout
       expect(File).to exist(import_directory + "/fr.yml")
     end
 
     it "imports nested locales" do
+      expect { importer.import }.to output.to_stdout
       expected = { "type" => { "country" => "Pays" } }
       expect(yaml_translation_data).to include("world_location" => hash_including(expected))
     end
 
     it "imports arrays from CSV as arrays" do
+      expect { importer.import }.to output.to_stdout
       expected =  { "fruit" => ["Pommes", "Bananes", "Poires"] }
       expect(yaml_translation_data).to include("world_location" => hash_including(expected))
     end
 
     it "imports string 'nil' as nil" do
+      expect { importer.import }.to output.to_stdout
       expected = { "things" => nil }
       expect(yaml_translation_data).to include("world_location" => hash_including(expected))
     end
 
     it "imports string ':thing' as symbol" do
+      expect { importer.import }.to output.to_stdout
       expected = { "sentiment" => :bof }
       expect(yaml_translation_data).to include("world_location" => hash_including(expected))
     end
 
     it "imports integer strings as integers" do
+      expect { importer.import }.to output.to_stdout
       expected = { "price" => 123 }
       expect(yaml_translation_data).to include("shared" => hash_including(expected))
     end
 
     it "imports boolean values as booleans, not strings" do
+      expect { importer.import }.to output.to_stdout
       expected = { "key1" => true, "key2" => false }
       expect(yaml_translation_data).to include("shared" => hash_including(expected))
     end
   end
 
   context "when there are multiple files per locale" do
-    before do
-      importer = described_class.new(
+    let(:importer) do
+      described_class.new(
         locale: "fr",
         csv_path: "spec/locales/importer/fr.csv",
         import_directory: import_directory,
         multiple_files_per_language: true
       )
-      importer.import
     end
 
     it "creates multiple YAML files per language in the language's directory" do
+      expect { importer.import }.to output.to_stdout
       expect(File).to exist(import_directory + "/fr/world_location.yml")
                   .and exist(import_directory + "/fr/shared.yml")
     end
 
     it "imports only 'world_location' locales to the relevant file" do
+      expect { importer.import }.to output.to_stdout
       yaml_translation_data = YAML.load_file(import_directory + "/fr/world_location.yml")["fr"]
       expect(yaml_translation_data).to match("world_location" => anything)
     end
 
     it "imports only 'shared' locales to the relevant file" do
+      expect { importer.import }.to output.to_stdout
       yaml_translation_data = YAML.load_file(import_directory + "/fr/shared.yml")["fr"]
       expect(yaml_translation_data).to match("shared" => anything)
     end

--- a/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
@@ -4,6 +4,12 @@ require "spec_helper"
 
 RSpec.describe MissingEnglishLocales do
   context "where there are missing English locales" do
+    before do
+      I18n.backend.store_translations :en, { browse: { same_key: "value" } }
+      I18n.backend.store_translations :cy, { browse: { same_key: "value" } }
+      I18n.backend.store_translations :cy, { browse: { extra_key: "extra_key" } }
+    end
+
     let(:all_locales) do
       [
         {
@@ -31,6 +37,11 @@ RSpec.describe MissingEnglishLocales do
   end
 
   context "where there aren't missing English locales" do
+    before do
+      I18n.backend.store_translations :en, { browse: { same_key: "value" } }
+      I18n.backend.store_translations :cy, { browse: { same_key: "value" } }
+    end
+
     let(:all_locales) do
       [
         {

--- a/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
+++ b/spec/rails_translation_manager/locale_checker/missing_english_locales_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe MissingEnglishLocales do
       expect(described_class.new(all_locales).report)
         .to eq(
           <<~OUTPUT.chomp
-            \e[31m[ERROR]\e[0m Missing English locales, either remove these keys from the foreign locales or add them to the English locales
+            \e[31m[ERROR]\e[0m Missing English locales, either remove them from the foreign locale files or add them to the English locale files
 
-            \e[1mMissing English keys:\e[22m ["browse.extra_key"]
+            \e[1mMissing English locales:\e[22m ["browse.extra_key"]
             \e[1mFound in:\e[22m [:cy]
           OUTPUT
         )

--- a/spec/rails_translation_manager/locale_checker_spec.rb
+++ b/spec/rails_translation_manager/locale_checker_spec.rb
@@ -4,6 +4,12 @@ require "spec_helper"
 
 RSpec.describe RailsTranslationManager::LocaleChecker do
   context "when the locales are valid" do
+    before do
+      I18n.backend.load_translations(
+        ["spec/locales/in_sync/cy/browse.yml", "spec/locales/in_sync/en/browse.yml"]
+      )
+    end
+
     it "calls each checker class" do
       described_class::CHECKER_CLASSES.each do |checker|
         expect_any_instance_of(checker).to receive(:report)
@@ -24,6 +30,12 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
   end
 
   context "when the locales are not valid" do
+    before do
+      I18n.backend.load_translations(
+        ["spec/locales/out_of_sync/cy.yml", "spec/locales/out_of_sync/en.yml"]
+      )
+    end
+
     it "calls each checker class" do
       described_class::CHECKER_CLASSES.each do |checker|
         expect_any_instance_of(checker).to receive(:report)

--- a/spec/rails_translation_manager/locale_checker_spec.rb
+++ b/spec/rails_translation_manager/locale_checker_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
         expect_any_instance_of(checker).to receive(:report)
       end
 
-      described_class.new("spec/locales/in_sync/**/*.yml").validate_locales
+      expect { described_class.new("spec/locales/in_sync/**/*.yml").validate_locales }
+        .to output.to_stdout
     end
 
     it "outputs a confirmation" do
@@ -24,6 +25,8 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
     end
 
     it "returns true" do
+      allow($stdout).to receive(:puts)
+
       expect(described_class.new("spec/locales/in_sync/**/*.yml").validate_locales)
         .to eq(true)
     end
@@ -41,38 +44,33 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
         expect_any_instance_of(checker).to receive(:report)
       end
 
-      described_class.new("spec/locales/out_of_sync/*.yml").validate_locales
+      expect { described_class.new("spec/locales/out_of_sync/*.yml").validate_locales }
+        .to output.to_stdout
     end
 
     it "outputs the report" do
-      printed = capture_stdout do
-        described_class.new("spec/locales/out_of_sync/*.yml").validate_locales
-      end
-
-      expect(printed.scan(/\[ERROR\]/).count).to eq(3)
+      # expect output to contain 3 errors ([ERROR])
+      expect { described_class.new("spec/locales/out_of_sync/*.yml").validate_locales }
+        .to output(/(?:\[ERROR\](?:.|\n)*){3}/).to_stdout
     end
 
     it "returns false" do
+      allow($stdout).to receive(:puts)
+
       expect(described_class.new("spec/locales/out_of_sync/*.yml").validate_locales)
         .to eq(false)
     end
   end
 
   context "when the locale path doesn't relate to any YAML files" do
-    it "doesn't call any checker classes" do
-      described_class::CHECKER_CLASSES.each do |checker|
-        expect_any_instance_of(checker).to_not receive(:report)
-      end
-
-      described_class.new("some/random/path").validate_locales
-    end
-
     it "outputs an error message" do
       expect { described_class.new("some/random/path").validate_locales }
         .to output("No locale files found for the supplied path\n").to_stdout
     end
 
     it "returns false" do
+      allow($stdout).to receive(:puts)
+
       expect(described_class.new("some/random/path").validate_locales)
         .to eq(false)
     end

--- a/spec/rails_translation_manager/locale_checker_spec.rb
+++ b/spec/rails_translation_manager/locale_checker_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
     end
 
     it "returns true" do
-      allow($stdout).to receive(:puts)
-
-      expect(described_class.new("spec/locales/in_sync/**/*.yml").validate_locales)
-        .to eq(true)
+      outcome = nil
+      expect { outcome = described_class.new("spec/locales/in_sync/**/*.yml").validate_locales }.to output.to_stdout
+      expect(outcome).to be(true)
     end
   end
 
@@ -55,10 +54,9 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
     end
 
     it "returns false" do
-      allow($stdout).to receive(:puts)
-
-      expect(described_class.new("spec/locales/out_of_sync/*.yml").validate_locales)
-        .to eq(false)
+      outcome = nil
+      expect { outcome = described_class.new("spec/locales/out_of_sync/*.yml").validate_locales }.to output.to_stdout
+      expect(outcome).to be(false)
     end
   end
 
@@ -69,10 +67,9 @@ RSpec.describe RailsTranslationManager::LocaleChecker do
     end
 
     it "returns false" do
-      allow($stdout).to receive(:puts)
-
-      expect(described_class.new("some/random/path").validate_locales)
-        .to eq(false)
+      outcome = nil
+      expect { outcome = described_class.new("some/random/path").validate_locales }.to output.to_stdout
+      expect(outcome).to be(false)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require "climate_control"
 RSpec.configure do |config|
   config.before do
     I18n.available_locales = %i[en cy]
-    config.before { allow($stdout).to receive(:puts) }
     I18n.backend.store_translations :en, i18n: { plural: { keys: %i[one other],
                                                            rule:
                                                              lambda do |n|
@@ -25,14 +24,5 @@ RSpec.configure do |config|
                                                                end
                                                              end } }
 
-  end
-
-  def capture_stdout(&blk)
-    old = $stdout
-    $stdout = fake = StringIO.new
-    blk.call
-    fake.string
-  ensure
-    $stdout = old
   end
 end

--- a/spec/tasks/translation_spec.rb
+++ b/spec/tasks/translation_spec.rb
@@ -20,7 +20,7 @@ describe "rake tasks" do
     end
 
     it "calls the Importer class with the csv and import paths" do
-      task.execute(csv_path: csv_path)
+      expect { task.execute(csv_path: csv_path) }.to output.to_stdout
 
       expect(RailsTranslationManager::Importer)
         .to have_received(:new)
@@ -44,7 +44,10 @@ describe "rake tasks" do
     end
 
     it "calls the importer class for each target path" do
-      task.execute(csv_directory: csv_directory, multiple_files_per_language: true)
+      expect { task.execute(csv_directory: csv_directory, multiple_files_per_language: true) }
+        .to output
+        .to_stdout
+
       import_paths = Dir["spec/locales/importer/*.csv"]
 
       import_paths.each do |csv_path|


### PR DESCRIPTION
After comparing foreign vs English keys locally, we then lookup the keys
to check if it exists in external libraries, e.g `rails-i18n`. As shared
translations can be patchy concerning certain languages [1], we may need
to add them directly into the foreign locale files.

Currently, adding keys not found in the local English locale files will
raise an error when the checker runs. This commit updates the code to
lookup the key across I18n before raising, to verify the English key is
really missing.