### PR TITLE
Load plural files after initialising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.2
+
+* Load plural rules after initialising app https://github.com/alphagov/rails_translation_manager/pull/61
+
 # 1.6.1
 
 * Audits plural rules and ensures consistent formatting https://github.com/alphagov/rails_translation_manager/pull/57

--- a/lib/rails_translation_manager.rb
+++ b/lib/rails_translation_manager.rb
@@ -20,14 +20,6 @@ require "rails_translation_manager/exporter"
 require "rails_translation_manager/importer"
 
 module RailsTranslationManager
-  rails_translation_manager = Gem::Specification.find_by_name("rails_translation_manager").gem_dir
-  I18n.load_path += ["#{rails_translation_manager}/config/locales/plurals.rb"]
-
-  if ENV["RAILS_TRANSLATION_MANAGER_LOAD_ALL_PLURAL_RULES"]
-    rails_i18n_path = Gem::Specification.find_by_name("rails-i18n").gem_dir
-    I18n.load_path += Dir["#{rails_i18n_path}/rails/pluralization/*.rb"]
-  end
-
   def self.locale_root
     if ENV["RAILS_TRANSLATION_MANAGER_LOCALE_ROOT"]
       Pathname.new(ENV["RAILS_TRANSLATION_MANAGER_LOCALE_ROOT"])

--- a/lib/rails_translation_manager/railtie.rb
+++ b/lib/rails_translation_manager/railtie.rb
@@ -5,5 +5,15 @@ module RailsTranslationManager
     rake_tasks do
       Dir[File.expand_path('../tasks/*.rake', File.dirname(__FILE__))].each { |f| load f }
     end
+
+    config.after_initialize do
+      if ENV["RAILS_TRANSLATION_MANAGER_LOAD_ALL_PLURAL_RULES"]
+        rails_i18n_path = Gem::Specification.find_by_name("rails-i18n").gem_dir
+        I18n.load_path += Dir["#{rails_i18n_path}/rails/pluralization/*.rb"]
+      end
+
+      rails_translation_manager = Gem::Specification.find_by_name("rails_translation_manager").gem_dir
+      I18n.load_path += ["#{rails_translation_manager}/config/locales/plurals.rb"]
+    end
   end
 end

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end


### PR DESCRIPTION
Previously, config/plurals.rb was added to I18n's load path before
`rails-i18n`'s shared files. This led to plural rules defined in
`rails-i18n` overwriting the rule set in RTM, due to being included
later in the load path. This only affected the language plural rules
that exist in both RTM and `rails-i18n`.

We want RTM's the ability to overwrite `rails-i18n`'s version as can be 
incorrect for certain languages.

Before
```
I18n.load_path.each_with_index { |x, i| if x =~ /fa.rb|plurals.rb/; puts [x,i]; end }

/Users/peterhartshorn/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rails_translation_manager-1.6.1/config/locales/plurals.rb
68
/Users/peterhartshorn/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.6/lib/rails_i18n/../../rails/pluralization/fa.rb
436
```

After
```
[1] pry(#<LocalesValidationTest>)> I18n.load_path.each_with_index { |x, i| if x =~ /fa.rb|plurals.rb/; puts [x,i]; end }
/Users/peterhartshorn/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.6/lib/rails_i18n/../../rails/pluralization/fa.rb
435
/Users/peterhartshorn/govuk/rails_translation_manager/config/locales/plurals.rb
555
```