### PR TITLE
Fix argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.3
+
+* Use proc for single plural languages https://github.com/alphagov/rails_translation_manager/pull/62
+
 # 1.6.2
 
 * Load plural rules after initialising app https://github.com/alphagov/rails_translation_manager/pull/61

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -79,9 +79,9 @@
   # Yiddish
   yi: { i18n: { plural: { keys: %i[one other], rule: ->(n) { n == 1 ? :one : :other } } } },
   # Chinese
-  zh: { i18n: { plural: { keys: %i[other], rule: -> { :other } } } },
+  zh: { i18n: { plural: { keys: %i[other], rule: proc { :other } } } },
   # Chinese Hong Kong
-  "zh-hk": { i18n: { plural: { keys: %i[other], rule: -> { :other } } } },
+  "zh-hk": { i18n: { plural: { keys: %i[other], rule: proc { :other } } } },
   # Chinese Taiwan
-  "zh-tw": { i18n: { plural: { keys: %i[other], rule: -> { :other } } } }
+  "zh-tw": { i18n: { plural: { keys: %i[other], rule: proc { :other } } } }
 }

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.6.2"
+  VERSION = "1.6.3"
 end


### PR DESCRIPTION
lambdas are sensitive to arguments and so we should use a proc instead
when configuring 1 keys plurals as we don't care about what's passed in.
`rails-i18n` handles these in a similar way [1], however using `proc` is
preferred syntax.

[1]: https://github.com/svenfuchs/rails-i18n/blob/ad26c50e1fea0eac2c9b85815f2c051f33a78045/lib/rails_i18n/common_pluralizations/other.rb#L5
