### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [ 2.7, '3.0', 3.1 ]
+        ruby: [2.7, '3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/lib/rails_translation_manager/importer.rb
+++ b/lib/rails_translation_manager/importer.rb
@@ -73,7 +73,7 @@ class RailsTranslationManager::Importer
     group_csv_by_file(csv).each do |group|
       language_dir =  File.join(import_directory, locale)
 
-      Dir.mkdir(language_dir) unless Dir.exists?(language_dir)
+      Dir.mkdir(language_dir) unless Dir.exist?(language_dir)
 
       import_yml_path = File.join(import_directory, locale, "#{group[0]}.yml")
       import_csv(group[1], import_yml_path)


### PR DESCRIPTION
Ruby 3.2 was released on December 25th 2022