### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.8.0
 
 * Drop support for Ruby 3.1, keep supporting Ruby 3.2, use Ruby 3.3 as default https://github.com/alphagov/rails_translation_manager/pull/78 
 

--- a/lib/rails_translation_manager/version.rb
+++ b/lib/rails_translation_manager/version.rb
@@ -1,3 +1,3 @@
 module RailsTranslationManager
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end


### PR DESCRIPTION
* Drop support for Ruby 3.1, keep supporting Ruby 3.2, use Ruby 3.3 as default https://github.com/alphagov/rails_translation_manager/pull/78